### PR TITLE
Add user documentation site (MyST + GitHub Pages)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install mystmd
+        run: npm install -g mystmd
+
+      - name: Build site
+        run: |
+          cd docs
+          myst build --html
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 .yarn/
 .pnp.*
 .venv/
+docs/_build/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ jlpm watch:src
 jupyter lab --no-browser
 ```
 
-## Architecture
+## Documentation
 
-See [docs/design.md](docs/design.md) for the full design specification.
+- **User guide:** how to use the extension day-to-day. Published at https://boettiger-lab.github.io/jupyter-geoagent/ (once GitHub Pages is configured) or read the source at [docs/usage.md](docs/usage.md).
+- **Design specification:** architecture and module reuse reference for contributors at [docs/design.md](docs/design.md).

--- a/docs/design.md
+++ b/docs/design.md
@@ -3,6 +3,10 @@
 **Date:** 2026-04-14
 **Repo:** `boettiger-lab/jupyter-geoagent`
 
+:::{note}
+This is an internal architecture reference for contributors. If you are looking for how to use the extension, see the [Usage Guide](usage.md) instead.
+:::
+
 ## Problem
 
 Geo-agent web apps require hand-authoring a `layers-input.json` config file, writing an `index.html`, and deploying to a URL. This creates friction for researchers who want to explore STAC catalog data, compose maps, and run spatial queries without writing code or managing infrastructure. The target user is someone accustomed to ArcGIS-style GIS workflows — they expect to click, not code.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,16 @@
+# jupyter-geoagent
+
+A JupyterLab extension for interactive geospatial data exploration: browse STAC catalogs, add layers to a map, style and filter them, run SQL queries via MCP, and export reproducible artifacts — all without writing code.
+
+## Where to go next
+
+- **[Usage Guide](usage.md)** — how to use the extension day-to-day, with a quickstart and common patterns
+- **[Design Specification](design.md)** — architecture, module reuse, data flow (internal reference for contributors)
+
+## Install
+
+```bash
+pip install jupyter-geoagent
+```
+
+See the project [README on GitHub](https://github.com/boettiger-lab/jupyter-geoagent) for development setup.

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -1,0 +1,14 @@
+version: 1
+project:
+  title: jupyter-geoagent
+  description: Interactive geospatial data exploration in JupyterLab
+  github: https://github.com/boettiger-lab/jupyter-geoagent
+  toc:
+    - file: index.md
+    - file: usage.md
+    - file: design.md
+  exclude:
+    - superpowers/**
+    - _build/**
+site:
+  template: book-theme

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,55 @@
+# Usage Guide
+
+The GeoAgent Map panel in JupyterLab lets you browse STAC catalogs, add layers to an interactive map, style and filter them, query tabular data with SQL, and export reproducible artifacts — all without writing code.
+
+This guide has two parts: a **Quickstart** walkthrough of the happy path, and a **Common Patterns** section with named how-tos you can jump to directly.
+
+## Quickstart
+
+From a fresh JupyterLab session to a shareable static map in about two minutes.
+
+### 1. Open the GeoAgent panel
+
+In the JupyterLab launcher, click **GeoAgent Map** (or choose `File > New > GeoAgent Map` from the menu). A new main-area panel opens with three regions:
+
+- **Left** — STAC catalog browser
+- **Center** — interactive map
+- **Right** — tabbed panel: *Layers*, *Query*, *Export*
+
+### 2. Browse the default catalog
+
+The left sidebar loads a default STAC catalog on open. Each entry shows a title and a short description. Nested catalogs have an expand arrow on the left; leaf collections have an **Add** button on the right.
+
+Type in the filter box to narrow the list by keyword (matches title, description, or id — including nested entries).
+
+### 3. Add a layer to the map
+
+Click **Add** on any leaf collection. The map recenters to the dataset's bounding box and the layer appears. The *Layers* tab (right sidebar) auto-selects the new layer so its details pane is visible at the bottom.
+
+### 4. Adjust the layer
+
+In the *Layers* tab:
+
+- Toggle the checkbox to show or hide
+- Click the **x** to remove
+- With the layer selected, scroll the details pane:
+  - **Vector layers** — *Set Style* (fill / line color, width, opacity) and *Set Filter* (property → operator → value)
+  - **Raster layers** — opacity slider, colormap dropdown, rescale (min / max)
+
+### 5. Run a SQL query
+
+Switch to the *Query* tab. If the active layers include parquet assets and an MCP server is configured, you can run SQL directly against the data:
+
+1. Write a query in the editor
+2. Click **Run Query**
+3. Results render as a table below the editor
+
+### 6. Export a shareable map
+
+Switch to the *Export* tab. Three buttons:
+
+- **Export Static HTML Map** — downloads a self-contained `map-export.html` you can email, host anywhere, or open offline
+- **Export layers-input.json** — the config format consumed by the `geo-agent-template` web app; use this to promote your exploration into a deployed LLM-chat map
+- **Export Tool Call Log** — a JSON record of every action you took in this session; useful for reproducibility and debugging
+
+The static HTML you just downloaded is a complete interactive map of your current view and layer state.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -55,3 +55,78 @@ Switch to the *Export* tab. Three buttons:
 - **Export Static HTML Map** — downloads a self-contained `map-export.html` you can email, host anywhere, or open offline
 - **Export layers-input.json** — the config format consumed by the `geo-agent-template` web app; use this to promote your exploration into a deployed LLM-chat map
 - **Export Tool Call Log** — a JSON record of every action you took in this session; useful for reproducibility and debugging
+
+## Common Patterns
+
+Each pattern is a self-contained how-to.
+
+### Switch to a different STAC catalog
+
+1. In the left sidebar, replace the URL in the catalog field with the new catalog URL
+2. Click **Load**
+3. The browser resets and shows the new catalog's collections
+
+Previously added layers stay on the map — switching catalogs does not clear the map.
+
+### Style a vector layer
+
+1. Add the vector dataset from the catalog
+2. In the *Layers* tab, click the layer to select it
+3. Expand **Set Style** in the details pane
+4. Edit any supported keys (fill color, line width, fill opacity, etc.)
+5. Changes apply live to the map
+
+Style changes are recorded in the tool-call log as `set_style` calls.
+
+### Filter a vector layer by a property
+
+1. Select the layer in the *Layers* tab
+2. Expand **Set Filter** in the details pane
+3. Choose the property from the dropdown (populated from the layer's schema)
+4. Pick an operator (`==`, `!=`, `>`, `<`, `in`, etc.)
+5. Enter the value
+6. The map updates immediately; only features matching the filter render
+
+To clear, open **Set Filter** again and submit an empty filter.
+
+### Filter a vector layer by a query result
+
+When a simple property filter isn't enough — for example, you want features whose id appears in the result of an aggregate — use **Filter by Query**:
+
+1. Select the layer in the *Layers* tab
+2. Expand **Filter by Query** (only shown for vector layers when an MCP server is configured)
+3. Write SQL that returns an id list (the column matching the layer's id field)
+4. Submit — the results are pushed to the map as a filter of the form `["in", ["get", "<id_field>"], ...values]`
+
+### Run spatial and aggregation queries
+
+1. Switch to the *Query* tab
+2. Write a query against a parquet asset (visible in the layer details, or from the STAC catalog)
+3. Click **Run Query**
+4. Scroll the result output
+
+Queries run through the configured MCP server (a DuckDB server by default). Spatial functions (`ST_Intersects`, `ST_Area`, etc.) are available if the server has the DuckDB spatial extension loaded.
+
+### Share a map with a colleague
+
+1. Compose your map: add layers, style, filter, pan and zoom to the view you want
+2. *Export* tab → **Export Static HTML Map**
+3. Send the downloaded `map-export.html` file
+
+The file inlines MapLibre GL JS and PMTiles from CDN, plus all your layer configs and the current view. It works offline for vector layers; raster layers need network access for the tile server.
+
+### Hand off to a geo-agent web app deployment
+
+When you want an LLM-chat map on top of the exploration you just built:
+
+1. *Export* tab → **Export layers-input.json**
+2. Clone the [`geo-agent-template`](https://github.com/boettiger-lab/geo-agent-template) repo
+3. Replace its `layers-input.json` with the file you just exported
+4. Follow that repo's deploy instructions
+
+### Reproduce a session
+
+1. *Export* tab → **Export Tool Call Log**
+2. The resulting `tool-calls.json` has every action (with arguments and timestamps) you performed in order
+
+A full replay UI — loading the log and re-executing calls inside the panel — is planned but not yet built. For now, the log is useful for: sharing a precise bug report, auditing what was done, or manually re-tracing steps.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,38 +72,40 @@ Previously added layers stay on the map — switching catalogs does not clear th
 
 1. Add the vector dataset from the catalog
 2. In the *Layers* tab, click the layer to select it
-3. Expand **Set Style** in the details pane
-4. Edit any supported keys (fill color, line width, fill opacity, etc.)
-5. Changes apply live to the map
+3. Scroll to the **Style** form in the details pane
+4. Edit the JSON object (MapLibre paint properties — e.g. `{"fill-color": "#2E7D32", "fill-opacity": 0.5}`)
+5. Click **Apply** to push the change to the map; **Reset to default** restores the layer's original style
 
-Style changes are recorded in the tool-call log as `set_style` calls.
+Expand "Style syntax (from geo-agent)" below the form for a full list of supported keys. Applied styles are recorded in the tool-call log as `set_style` calls.
 
 ### Filter a vector layer by a property
 
-1. Select the layer in the *Layers* tab
-2. Expand **Set Filter** in the details pane
-3. Choose the property from the dropdown (populated from the layer's schema)
-4. Pick an operator (`==`, `!=`, `>`, `<`, `in`, etc.)
-5. Enter the value
-6. The map updates immediately; only features matching the filter render
+The filter is authored as a [MapLibre filter expression](https://maplibre.org/maplibre-style-spec/expressions/) in JSON form.
 
-To clear, open **Set Filter** again and submit an empty filter.
+1. Select the layer in the *Layers* tab
+2. Scroll to the **Filter** form in the details pane
+3. Edit the JSON textarea — e.g. `["==", ["get", "MNG_AGENCY"], "State Parks"]` or `["match", ["get", "class"], ["forest", "wetland"], true, false]`
+4. Click **Apply**
+5. The map updates immediately; only features matching the filter render
+
+Use **Clear** to remove the filter, or **Reset to default** to restore the layer's original filter. Expand "Filter syntax (from geo-agent)" below the form for more examples.
 
 ### Filter a vector layer by a query result
 
-When a simple property filter isn't enough — for example, you want features whose id appears in the result of an aggregate — use **Filter by Query**:
+When a simple property filter isn't enough — for example, you want features whose id appears in the result of an aggregate — use **Filter by SQL query**:
 
 1. Select the layer in the *Layers* tab
-2. Expand **Filter by Query** (only shown for vector layers when an MCP server is configured)
-3. Write SQL that returns an id list (the column matching the layer's id field)
-4. Submit — the results are pushed to the map as a filter of the form `["in", ["get", "<id_field>"], ...values]`
+2. Scroll to the **Filter by SQL query** form (only rendered for vector layers when an MCP server is connected)
+3. In the SQL textarea, write a `SELECT` that returns a single column of id values — e.g. `SELECT HYBAS_ID FROM read_parquet('s3://…') WHERE UP_AREA > 50000`
+4. In the **ID property** input, enter the feature property on the layer to match against (for cng-datasets this is typically `_cng_fid`)
+5. Click **Apply**. The form reports how many features matched, and the map is filtered to those features. Behind the scenes the map receives a filter of the form `["in", ["get", "<id_property>"], ["literal", [id1, id2, ...]]]`.
 
 ### Run spatial and aggregation queries
 
-1. Switch to the *Query* tab
+1. Switch to the *Query* tab. If you have not already connected, confirm the MCP server URL and click **Connect**
 2. Write a query against a parquet asset (visible in the layer details, or from the STAC catalog)
-3. Click **Run Query**
-4. Scroll the result output
+3. Click **Run Query** (or press Ctrl+Enter)
+4. Scroll the result output below the editor
 
 Queries run through the configured MCP server (a DuckDB server by default). Spatial functions (`ST_Intersects`, `ST_Area`, etc.) are available if the server has the DuckDB spatial extension loaded.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,7 +10,7 @@ From a fresh JupyterLab session to a shareable static map in about two minutes.
 
 ### 1. Open the GeoAgent panel
 
-In the JupyterLab launcher, click **GeoAgent Map** (or choose `File > New > GeoAgent Map` from the menu). A new main-area panel opens with three regions:
+In the JupyterLab launcher, click **GeoAgent Map**. A new main-area panel opens with three regions:
 
 - **Left** — STAC catalog browser
 - **Center** — interactive map
@@ -30,19 +30,23 @@ Click **Add** on any leaf collection. The map recenters to the dataset's boundin
 
 In the *Layers* tab:
 
+- Click a layer row to select it — the details pane appears at the bottom
 - Toggle the checkbox to show or hide
 - Click the **x** to remove
-- With the layer selected, scroll the details pane:
-  - **Vector layers** — *Set Style* (fill / line color, width, opacity) and *Set Filter* (property → operator → value)
+- With a layer selected, the details pane shows:
+  - **Vector layers** — *Set Style* (fill and line colors, width, fill opacity) and *Set Filter* (property → operator → value)
   - **Raster layers** — opacity slider, colormap dropdown, rescale (min / max)
 
 ### 5. Run a SQL query
 
-Switch to the *Query* tab. If the active layers include parquet assets and an MCP server is configured, you can run SQL directly against the data:
+Switch to the *Query* tab. Queries run against a DuckDB MCP server.
 
-1. Write a query in the editor
-2. Click **Run Query**
-3. Results render as a table below the editor
+1. Confirm the MCP server URL at the top of the tab (a default is pre-filled) and click **Connect**
+2. Write a query in the editor (Ctrl+Enter also runs it)
+3. Click **Run Query**
+4. Results appear below the editor
+
+If you see the message "Enter an MCP server URL and click Connect," the server is not yet connected — update the URL if needed and click Connect.
 
 ### 6. Export a shareable map
 
@@ -51,5 +55,3 @@ Switch to the *Export* tab. Three buttons:
 - **Export Static HTML Map** — downloads a self-contained `map-export.html` you can email, host anywhere, or open offline
 - **Export layers-input.json** — the config format consumed by the `geo-agent-template` web app; use this to promote your exploration into a deployed LLM-chat map
 - **Export Tool Call Log** — a JSON record of every action you took in this session; useful for reproducibility and debugging
-
-The static HTML you just downloaded is a complete interactive map of your current view and layer state.


### PR DESCRIPTION
## Summary

- Scaffolds a MyST static docs site at `docs/` with a landing page, a user guide (`usage.md`), and the existing design spec brought into the TOC.
- The user guide has two halves: a 6-step Quickstart and 8 Common Patterns (switch catalogs, style a layer, filter by property, filter by SQL, run spatial queries, share a map, hand off to geo-agent, reproduce a session). Every pattern is grounded in real components (`SetStyleForm`, `SetFilterForm`, `FilterByQueryForm`) rather than hypothetical UI.
- Adds `.github/workflows/docs.yml` to build and deploy to GitHub Pages on every push to `main` that touches `docs/`.
- Updates `README.md` to point at both the user guide and the design spec.

Spec: `docs/superpowers/specs/2026-04-15-user-docs-site-design.md`
Plan: `docs/superpowers/plans/2026-04-15-user-docs-site.md`

## One-time manual step required before first deploy

GitHub Actions cannot enable Pages by itself. A repo admin needs to:

1. Go to **Settings → Pages**
2. Set **Build and deployment → Source** to **GitHub Actions**
3. Re-run the `Docs` workflow from the Actions tab (or push any `docs/` change)

After that, the site publishes to `https://boettiger-lab.github.io/jupyter-geoagent/` on every docs change.

## Test plan

- [x] `myst build --html` produces `docs/_build/html/{index,usage/index,design/index}.html` locally, exit 0
- [x] `superpowers/**` is excluded from the built site
- [x] YAML workflow parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] All content verified against source components (no hallucinated UIs)
- [x] After merge: enable Pages in repo settings, confirm first deploy succeeds, confirm three-page navigation renders