### PR TITLE
Expose map tools as JupyterLab commands for jupyter-ai

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -158,6 +158,44 @@ The frontend detects connectivity and falls back to the proxy automatically.
 
 The server extension can optionally manage a local DuckDB MCP server process for querying the user's own data. Configuration via JupyterLab settings or environment variables.
 
+## jupyter-ai Command Bridge
+
+The LLM chat panel drives the map through a short chain of pre-existing JupyterLab machinery:
+
+```
+ jupyter-ai persona (Claude / OpenCode / Goose)
+   │  (MCP tool call: execute_command)
+   ▼
+ jupyter_server_mcp  ──── discovers tools via the
+                          `jupyter_server_mcp.tools` entrypoint
+   │
+   ▼
+ jupyterlab_commands_toolkit  ── emits a `jupyterlab-command/v1` event
+   │
+   ▼
+ jupyterlab-eventlistener (browser)
+   │
+   ▼
+ app.commands.execute('geoagent:<tool>', args)
+   │
+   ▼
+ src/commands.ts handler
+   │  constructs MapManagerAdapter(controller, {onChange: refresh})
+   │  calls geo-agent's createMapTools(adapter, stubCatalog, mcpClient)
+   ▼
+ MapViewController  → map mutations  + ToolCallRecorder entry
+```
+
+Key pieces:
+
+- **`src/commands.ts`** — at plugin activation, loops over `createMapTools()` output and registers one JupyterLab command (`geoagent:<tool_name>`) per tool, setting `describedBy.args` to the tool's `inputSchema`. `list_all_commands` exposes that schema to the LLM.
+- **`src/core/active-panel.ts`** — module-scoped ref `{controller, mcpClient, recorder, refresh}` that `GeoAgentApp` updates on mount and clears on unmount. Multi-panel UX is last-mounted-wins (ArcGIS "active frame" idiom).
+- **`src/core/map-manager-adapter.ts`** — `MapManagerAdapter` wraps `MapViewController` with the `MapManager` surface geo-agent expects (`{success, ...}` return shapes, `getLayerSummaries`, `syncCheckbox`). Every mutation fires `options.onChange`, which bumps the React `layerRefreshKey` so the *Layers* panel re-renders in response to LLM-driven changes.
+
+What this enables: zero prompt-engineering per app. Any jupyter-ai persona with MCP access sees the commands via `list_all_commands` and can drive the map directly. Tools added upstream in `boettiger-lab/geo-agent` appear automatically after a `jlpm install` + rebuild — no per-command wiring in jupyter-geoagent.
+
+Tools currently skipped (in `SKIP_TOOLS`): `list_datasets` and `get_schema` (require geo-agent's sync `DatasetCatalog`; jupyter-geoagent uses an MCP-backed catalog instead), and `set_projection` (no globe/mercator toggle in `MapViewController` yet).
+
 ## Server Extension
 
 Lightweight Python package (`jupyter_geoagent`) registered as a Jupyter server extension:

--- a/docs/superpowers/plans/2026-04-23-jupyter-ai-command-bridge.md
+++ b/docs/superpowers/plans/2026-04-23-jupyter-ai-command-bridge.md
@@ -1,0 +1,668 @@
+# Jupyter-AI Command Bridge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose jupyter-geoagent's map-control tools as JupyterLab commands so jupyter-ai personas (OpenCode, Claude, Goose) can drive the map via natural-language chat, matching the behavior of the standalone geo-agent web app.
+
+**Architecture:** A `MapManagerAdapter` wraps `MapViewController` to satisfy the `geo-agent/app/map-tools.js` `MapManager` contract (`{success, ...}` return shapes, `getMapState`, `syncCheckbox`, etc.). Commands are registered **once** at extension activation, keyed off a module-scoped *active panel* reference that each `GeoAgentPanel` updates on mount/dispose. Each command dispatches through `createMapTools()` so descriptions and argument schemas match the JS geo-agent verbatim — no manual metadata drift. The pipeline `jupyter_server_mcp` → `jupyterlab_commands_toolkit.execute_command` → `app.commands.execute()` is already installed in `.venv`; we only need to register the commands.
+
+**Tech Stack:** TypeScript, JupyterLab 4 CommandRegistry (`describedBy.args` for JSON-Schema exposure), `geo-agent/app/map-tools.js` (tool definitions), `jupyter_server_mcp` + `jupyterlab_commands_toolkit` (MCP-over-events bridge, already installed).
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/core/map-manager-adapter.ts` | Create | Adapter that exposes `MapViewController` through the geo-agent `MapManager` surface expected by `createMapTools` |
+| `src/core/active-panel.ts` | Create | Module-scoped active-panel ref + setter/getter; holds `{controller, mcpClient, recorder, refresh}` |
+| `src/commands.ts` | Create | `registerGeoAgentCommands(app)` — registers one JupyterLab command per geo-agent map tool with `describedBy.args` schema |
+| `src/index.ts` | Modify | Call `registerGeoAgentCommands(app)` once in plugin activate |
+| `src/components/GeoAgentApp.tsx` | Modify | On `mapController` + `mcpClient` ready, call `setActivePanel(...)`; clear on unmount |
+| `src/typings/geo-agent.d.ts` | Modify | Extend `createMapTools` type to reflect async-capable `execute` |
+
+---
+
+## Non-goals (for this plan)
+
+- **Catalog tools** (`list_datasets`, `get_dataset_details`) — jupyter-geoagent uses MCP-backed catalog (`src/core/mcp-catalog.ts`), not geo-agent's sync `DatasetCatalog`. LLMs can call MCP catalog tools directly via the remote MCP server, so bridging these through commands is redundant. Skip.
+- **`set_projection`** — requires a globe/mercator toggle in `MapViewController`, which doesn't exist yet. Add in a later plan.
+- **Python entry-point wrapper** under `jupyter_server_mcp.tools` — would give friendlier tool names (`show_dataset` vs `execute_command("geoagent:show_dataset")`), but adds a Python module + packaging. Defer to a follow-up.
+
+## Tools registered in this plan (10)
+
+`show_layer`, `hide_layer`, `set_filter`, `clear_filter`, `reset_filter`, `set_style`, `reset_style`, `fly_to`, `filter_by_query`, `get_map_state`.
+
+---
+
+### Task 1: Adapter — core map-manipulation methods
+
+**Files:**
+- Create: `src/core/map-manager-adapter.ts`
+
+The geo-agent `MapManager` surface used by `createMapTools` is: `getLayerIds()`, `getVectorLayerIds()`, `showLayer(id)`, `hideLayer(id)`, `setFilter(id, filter)`, `clearFilter(id)`, `resetFilter(id)`, `setStyle(id, paint)`, `resetStyle(id)`, `flyTo({center, zoom})`, `getMapState()`, `setProjection(type)`, `syncCheckbox(id)`. Return shapes are `{success: bool, ...}`. Our `MapViewController` returns booleans and exposes slightly different state. This adapter bridges both.
+
+- [ ] **Step 1: Create adapter with pass-through and return-shape translation**
+
+```ts
+// src/core/map-manager-adapter.ts
+/**
+ * Adapter that exposes MapViewController through the MapManager surface
+ * expected by geo-agent/app/map-tools.js createMapTools().
+ *
+ * Two translations happen here:
+ *   1. Return shapes: MapViewController returns booleans; MapManager tools
+ *      expect { success: true, layer, ... } on success, { success: false,
+ *      error: "..." } on failure (with helpful "Available: a, b, c" hints).
+ *   2. Method names: getMapState (not getViewState), syncCheckbox (which
+ *      becomes a UI-refresh trigger).
+ */
+
+import type { MapViewController } from '../components/MapView';
+
+export interface MapManagerAdapterOptions {
+  /** Called after any state-mutating operation so React panels re-render. */
+  onChange?: () => void;
+}
+
+export class MapManagerAdapter {
+  constructor(
+    private controller: MapViewController,
+    private options: MapManagerAdapterOptions = {},
+  ) {}
+
+  // --- layer id enumerations (used by tool descriptions) ---
+
+  getLayerIds(): string[] {
+    return [...this.controller.layers.keys()];
+  }
+
+  getVectorLayerIds(): string[] {
+    return [...this.controller.layers.entries()]
+      .filter(([, s]) => s.type === 'vector')
+      .map(([id]) => id);
+  }
+
+  // --- show / hide ---
+
+  showLayer(layerId: string) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) {
+      return { success: false, error: `Unknown layer: ${layerId}. Available: ${this.getLayerIds().join(', ') || '(none)'}` };
+    }
+    this.controller.showLayer(layerId);
+    this.options.onChange?.();
+    return { success: true, layer: layerId, displayName: state.displayName, visible: true };
+  }
+
+  hideLayer(layerId: string) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) {
+      return { success: false, error: `Unknown layer: ${layerId}. Available: ${this.getLayerIds().join(', ') || '(none)'}` };
+    }
+    this.controller.hideLayer(layerId);
+    this.options.onChange?.();
+    return { success: true, layer: layerId, displayName: state.displayName, visible: false };
+  }
+
+  // --- filter ---
+
+  setFilter(layerId: string, filter: any) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+    if (state.type !== 'vector') return { success: false, error: `Layer '${layerId}' is raster — filtering only works on vector layers` };
+
+    if (filter === null || filter === undefined) {
+      this.controller.clearFilter(layerId);
+    } else {
+      this.controller.setFilter(layerId, filter);
+    }
+    this.options.onChange?.();
+
+    const features = this.controller.map.queryRenderedFeatures({ layers: [layerId] });
+    const result: any = {
+      success: true,
+      layer: layerId,
+      displayName: state.displayName,
+      filter: filter ?? null,
+      featuresInView: features.length,
+    };
+    if (filter && features.length === 0) {
+      result.warning = 'No features match this filter in the current view. Filter may be too restrictive or property values may not match. Use filter_by_query to verify via SQL.';
+    }
+    return result;
+  }
+
+  clearFilter(layerId: string) {
+    return this.setFilter(layerId, null);
+  }
+
+  resetFilter(layerId: string) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+    return this.setFilter(layerId, state.defaultFilter ?? null);
+  }
+
+  // --- style ---
+
+  setStyle(layerId: string, paintProps: Record<string, any>) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+
+    const updates: Array<{ property: string; success: boolean; error?: string }> = [];
+    for (const [prop, value] of Object.entries(paintProps)) {
+      try {
+        this.controller.setStyle(layerId, { [prop]: value });
+        updates.push({ property: prop, success: true });
+      } catch (err: any) {
+        updates.push({ property: prop, success: false, error: err.message });
+      }
+    }
+    this.options.onChange?.();
+    return { success: true, layer: layerId, displayName: state.displayName, updates };
+  }
+
+  resetStyle(layerId: string) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+    this.controller.resetStyle(layerId);
+    this.options.onChange?.();
+    return { success: true, layer: layerId, displayName: state.displayName };
+  }
+
+  // --- view ---
+
+  flyTo({ center, zoom }: { center: [number, number]; zoom?: number }) {
+    this.controller.flyTo(center, zoom);
+    return { success: true, center, zoom: zoom ?? this.controller.map.getZoom() };
+  }
+
+  getMapState() {
+    const layers: Record<string, any> = {};
+    for (const [id, state] of this.controller.layers) {
+      layers[id] = {
+        displayName: state.displayName,
+        type: state.type,
+        visible: state.visible,
+        opacity: state.opacity,
+        filter: state.filter ?? null,
+      };
+    }
+    const view = this.controller.getViewState();
+    return { success: true, view, layers };
+  }
+
+  // --- no-op on our side; geo-agent's tool code calls this to sync a legacy DOM checkbox ---
+  syncCheckbox(_layerId: string): void {
+    this.options.onChange?.();
+  }
+
+  // setProjection not supported yet — see plan non-goals.
+  setProjection(_type: string) {
+    return { success: false, error: 'Projection switching is not yet implemented in jupyter-geoagent.' };
+  }
+}
+```
+
+- [ ] **Step 2: Verify the adapter type-checks**
+
+Run: `jlpm build:lib`
+Expected: no errors. If `jlpm` is missing try `npx tsc --noEmit`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/map-manager-adapter.ts
+git commit -m "feat: add MapManagerAdapter bridging MapViewController to geo-agent MapManager contract"
+```
+
+---
+
+### Task 2: Active panel registry
+
+**Files:**
+- Create: `src/core/active-panel.ts`
+
+The command handlers are registered once, but they need access to the currently-focused panel's controller, MCP client, recorder, and refresh callback. A module-scoped ref holds these; panels update it on mount.
+
+- [ ] **Step 1: Create the registry module**
+
+```ts
+// src/core/active-panel.ts
+/**
+ * Module-scoped reference to the currently active GeoAgent panel.
+ *
+ * Commands registered at plugin-activate time dereference this to find the
+ * panel to operate on. Panels set it on mount and clear it on unmount.
+ * Multi-panel UX: last-mounted wins — matches the ArcGIS "active frame"
+ * idiom. (If both panels are open, the LLM operates on whichever was most
+ * recently shown.)
+ */
+
+import type { MapViewController } from '../components/MapView';
+import type { MCPClientWrapper } from './mcp';
+import type { ToolCallRecorder } from './tools';
+
+export interface ActivePanel {
+  controller: MapViewController;
+  mcpClient: MCPClientWrapper | null;
+  recorder: ToolCallRecorder;
+  /** Called after any tool mutation so React panels re-render. */
+  refresh: () => void;
+}
+
+let current: ActivePanel | null = null;
+
+export function setActivePanel(panel: ActivePanel | null): void {
+  current = panel;
+}
+
+export function getActivePanel(): ActivePanel | null {
+  return current;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `jlpm build:lib`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/core/active-panel.ts
+git commit -m "feat: add active-panel registry for LLM command routing"
+```
+
+---
+
+### Task 3: Relax geo-agent.d.ts execute typing
+
+**Files:**
+- Modify: `src/typings/geo-agent.d.ts`
+
+`createMapTools`'s `execute` can return a promise (e.g. `filter_by_query` is async). The current declaration says `any`, which technically works but is loose. Tighten to `any | Promise<any>` for clarity.
+
+- [ ] **Step 1: Adjust the declaration**
+
+Change `src/typings/geo-agent.d.ts` lines 30-41 from:
+
+```ts
+declare module 'geo-agent/app/map-tools.js' {
+  export function createMapTools(
+    mapManager: any,
+    catalog: any,
+    mcpClient?: any
+  ): Array<{
+    name: string;
+    description: string;
+    inputSchema: any;
+    execute: (args: Record<string, any>) => any;
+  }>;
+}
+```
+
+to:
+
+```ts
+declare module 'geo-agent/app/map-tools.js' {
+  export function createMapTools(
+    mapManager: any,
+    catalog: any,
+    mcpClient?: any
+  ): Array<{
+    name: string;
+    description: string;
+    inputSchema: any;
+    execute: (args: Record<string, any>) => any | Promise<any>;
+  }>;
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `jlpm build:lib`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/typings/geo-agent.d.ts
+git commit -m "chore: allow Promise return from createMapTools execute"
+```
+
+---
+
+### Task 4: Command registration
+
+**Files:**
+- Create: `src/commands.ts`
+
+The registration loops over the tool set from `createMapTools()` using the active panel's adapter + MCP client. Commands go through the adapter for every call (not cached), so a new panel's state is picked up without re-registering. The `label`, `caption`, and `describedBy.args` fields populate `list_all_commands` for the LLM.
+
+- [ ] **Step 1: Write the command registrar**
+
+```ts
+// src/commands.ts
+/**
+ * Register one JupyterLab command per geo-agent map tool.
+ *
+ * Wiring:
+ *   app.commands.addCommand('geoagent:<tool_name>', { execute, describedBy })
+ *     → jupyter-ai persona calls execute_command (via jupyter_server_mcp MCP tool)
+ *     → jupyterlab_commands_toolkit emits a jupyterlab-command/v1 event
+ *     → the frontend event listener calls app.commands.execute('geoagent:<tool_name>', args)
+ *     → this handler looks up the active panel and dispatches through createMapTools()
+ *
+ * Call this once at plugin activation. Commands stay registered for the
+ * lifetime of the JupyterLab session; they error clearly if no panel is open.
+ */
+
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { createMapTools } from 'geo-agent/app/map-tools.js';
+import { MapManagerAdapter } from './core/map-manager-adapter';
+import { getActivePanel } from './core/active-panel';
+
+/** Skip tools that depend on machinery jupyter-geoagent doesn't provide yet. */
+const SKIP_TOOLS = new Set([
+  'list_datasets',          // needs DatasetCatalog; jupyter-geoagent uses MCP-backed catalog
+  'get_dataset_details',    // same
+  'set_projection',         // MapViewController doesn't implement globe/mercator toggle
+]);
+
+const NO_PANEL_ERROR = JSON.stringify({
+  success: false,
+  error: 'No GeoAgent Map panel is open. Ask the user to open one from the JupyterLab launcher (File → New → GeoAgent Map).',
+});
+
+export function registerGeoAgentCommands(app: JupyterFrontEnd): void {
+  // Build the tool list once using stubs — we only use each entry's name,
+  // description, and inputSchema here. Real mapManager/catalog/mcpClient are
+  // resolved inside each execute handler from getActivePanel().
+  const stubManager = { getLayerIds: () => [], getVectorLayerIds: () => [] };
+  const stubCatalog = { getAll: () => [], get: () => null, getIds: () => [] };
+  const stubMcp = {};
+  const toolMetadata = createMapTools(stubManager as any, stubCatalog as any, stubMcp as any);
+
+  for (const meta of toolMetadata) {
+    if (SKIP_TOOLS.has(meta.name)) continue;
+
+    const commandId = `geoagent:${meta.name}`;
+
+    app.commands.addCommand(commandId, {
+      label: `GeoAgent: ${meta.name}`,
+      caption: firstLine(meta.description),
+      describedBy: { args: meta.inputSchema },
+      execute: async (args) => {
+        const panel = getActivePanel();
+        if (!panel) return NO_PANEL_ERROR;
+
+        const adapter = new MapManagerAdapter(panel.controller, { onChange: panel.refresh });
+        // Rebuild the tool with the real adapter + mcpClient so closures bind
+        // to the current panel's state.
+        const tools = createMapTools(adapter as any, stubCatalog as any, panel.mcpClient ?? undefined);
+        const tool = tools.find(t => t.name === meta.name);
+        if (!tool) {
+          return JSON.stringify({ success: false, error: `Tool '${meta.name}' not found in createMapTools output.` });
+        }
+
+        const argsObj = (args ?? {}) as Record<string, any>;
+        try {
+          const result = await Promise.resolve(tool.execute(argsObj));
+          const resultStr = typeof result === 'string' ? result : JSON.stringify(result);
+          panel.recorder.record(meta.name, argsObj, resultStr);
+          return resultStr;
+        } catch (err: any) {
+          const errResult = JSON.stringify({ success: false, error: err?.message ?? String(err) });
+          panel.recorder.record(meta.name, argsObj, errResult);
+          return errResult;
+        }
+      },
+    });
+  }
+}
+
+function firstLine(s: string): string {
+  const idx = s.indexOf('\n');
+  return idx === -1 ? s : s.slice(0, idx);
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `jlpm build:lib`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/commands.ts
+git commit -m "feat: register geo-agent map tools as JupyterLab commands"
+```
+
+---
+
+### Task 5: Wire registration into extension activation
+
+**Files:**
+- Modify: `src/index.ts` — add one import and one call in `activate`
+
+- [ ] **Step 1: Import and call the registrar**
+
+In `src/index.ts`, add after the existing `import { GeoAgentPanel } from './panel';` line:
+
+```ts
+import { registerGeoAgentCommands } from './commands';
+```
+
+Then, inside the `activate` function, immediately after `console.log('jupyter-geoagent extension activated');`:
+
+```ts
+    registerGeoAgentCommands(app);
+```
+
+The full `activate` function should read:
+
+```ts
+  activate: (
+    app: JupyterFrontEnd,
+    launcher: ILauncher | null,
+    restorer: ILayoutRestorer | null,
+  ) => {
+    console.log('jupyter-geoagent extension activated');
+    registerGeoAgentCommands(app);
+
+    const tracker = new WidgetTracker<GeoAgentPanel>({ namespace: 'geoagent' });
+    // ... rest unchanged
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `jlpm build:lib`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/index.ts
+git commit -m "feat: register geoagent commands at plugin activation"
+```
+
+---
+
+### Task 6: Panels update the active-panel ref on mount/unmount
+
+**Files:**
+- Modify: `src/components/GeoAgentApp.tsx` — add a `useEffect` that syncs `setActivePanel` when `mapController` + `mcpClient` are ready; clear on unmount
+
+- [ ] **Step 1: Add the import**
+
+In `src/components/GeoAgentApp.tsx`, add after the existing `import { MCPClientWrapper } from '../core/mcp';` line:
+
+```ts
+import { setActivePanel } from '../core/active-panel';
+```
+
+- [ ] **Step 2: Add the sync effect**
+
+After the existing `React.useEffect` block that handles MCP connection (the one starting with `React.useEffect(() => { if (!mcpServerUrl) return;`), add a new effect:
+
+```tsx
+  // Publish this panel as the active target for LLM-driven commands.
+  // Cleared on unmount so stale controllers don't get poked by the next
+  // opened panel.
+  React.useEffect(() => {
+    if (!mapController) return;
+    setActivePanel({
+      controller: mapController,
+      mcpClient,
+      recorder: recorderRef.current,
+      refresh: () => setLayerRefreshKey(k => k + 1),
+    });
+    return () => {
+      setActivePanel(null);
+    };
+  }, [mapController, mcpClient]);
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `jlpm build:lib`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/GeoAgentApp.tsx
+git commit -m "feat: sync GeoAgentApp lifecycle to active-panel ref"
+```
+
+---
+
+### Task 7: Production build and local install
+
+**Files:** (none — runs commands)
+
+- [ ] **Step 1: Production build**
+
+Run: `jlpm build:prod`
+Expected: compiles cleanly, writes `jupyter_geoagent/labextension/static/*.js`.
+
+- [ ] **Step 2: Reinstall (picks up the new labextension bundle)**
+
+Run: `.venv/bin/pip install -e . --no-deps --no-build-isolation`
+Expected: successful install of `jupyter-geoagent 0.1.0`.
+
+- [ ] **Step 3: Restart the running JupyterLab**
+
+The user has a JupyterLab process running at PID visible via `ps aux | grep jupyter-lab`. Ask the user to restart it (Ctrl-C in its terminal and re-run their launch command). Do not kill the process on their behalf.
+
+Expected: a fresh JupyterLab session that loads the rebuilt `@boettiger-lab/jupyter-geoagent` bundle.
+
+---
+
+### Task 8: Manual verification through @OpenCode
+
+**Files:** (none — runs the chat UI)
+
+- [ ] **Step 1: Open a GeoAgent Map panel**
+
+In JupyterLab, click **GeoAgent Map** in the launcher. Wait for the map to load.
+
+- [ ] **Step 2: Ask @OpenCode to list the new commands**
+
+In a jupyter-ai chat, send:
+
+```
+@OpenCode use list_all_commands to find every command whose id starts with "geoagent:". Show the list.
+```
+
+Expected: OpenCode calls `list_all_commands(query="geoagent:")` and returns 10+ entries, including `geoagent:open`, `geoagent:show_layer`, `geoagent:hide_layer`, `geoagent:set_filter`, `geoagent:clear_filter`, `geoagent:reset_filter`, `geoagent:set_style`, `geoagent:reset_style`, `geoagent:fly_to`, `geoagent:filter_by_query`, `geoagent:get_map_state`. Each should carry an `args` JSON-Schema and a caption.
+
+- [ ] **Step 3: Add a layer via the UI, then ask @OpenCode for state**
+
+Add one layer from the catalog (e.g. *Irrecoverable Carbon*). Then:
+
+```
+@OpenCode call execute_command("geoagent:get_map_state", {}). Summarize the layers.
+```
+
+Expected: one layer listed, with its id, `visible: true`, type, and current filter.
+
+- [ ] **Step 4: Ask @OpenCode to hide then show the layer**
+
+```
+@OpenCode hide the layer you just saw, then show it again. Use the geoagent commands.
+```
+
+Expected: OpenCode calls `execute_command("geoagent:hide_layer", {layer_id: "..."})`, then `execute_command("geoagent:show_layer", {layer_id: "..."})`. The map visually hides and re-shows the layer; the Layers tab checkbox updates accordingly.
+
+- [ ] **Step 5: Ask @OpenCode for a SQL-driven filter**
+
+```
+@OpenCode filter the active layer to features where <some_property> = <some_value>, using the filter_by_query command.
+```
+
+Expected: OpenCode constructs a SQL query, calls `geoagent:filter_by_query`, and the map reflects the filtered features. The Layers tab shows the filter.
+
+- [ ] **Step 6: Verify the ToolCallRecorder captures LLM-driven calls**
+
+Switch to the **Export** tab, click **Export Tool Call Log**. Open the downloaded JSON.
+
+Expected: entries for each LLM-driven command (`show_layer`, `hide_layer`, `filter_by_query`, etc.) with timestamps, args, and stringified results.
+
+---
+
+### Task 9: Push branch and open PR
+
+**Files:** (none)
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin feat/jupyter-ai-command-bridge`
+
+- [ ] **Step 2: Open PR via `gh pr create`**
+
+```bash
+gh pr create --title "Expose map tools as JupyterLab commands for jupyter-ai" --body "$(cat <<'EOF'
+## Summary
+
+- Register each geo-agent map tool as a JupyterLab command (`geoagent:show_layer`, `geoagent:set_filter`, etc.) with `describedBy.args` so jupyter-ai personas (OpenCode, Claude, Goose) can drive the map via chat.
+- Add `MapManagerAdapter` bridging `MapViewController` to the `MapManager` contract expected by `createMapTools` — same tool descriptions and behavior as the standalone geo-agent web app, no duplication.
+- Add `active-panel` registry so commands target whichever panel is currently mounted; panel updates this ref on mount and clears it on unmount.
+
+Skipped for follow-up: `list_datasets` / `get_dataset_details` (jupyter-geoagent uses MCP-backed catalog, not `DatasetCatalog`); `set_projection` (needs globe/mercator toggle in `MapViewController`).
+
+## Test plan
+
+- [ ] `@OpenCode use list_all_commands to find commands matching "geoagent:"` returns 10+ tool entries with JSON schemas
+- [ ] `@OpenCode call execute_command("geoagent:get_map_state", {})` returns current layers + view
+- [ ] `@OpenCode hide layer X / show layer X` drives the map; UI checkbox reflects state
+- [ ] `@OpenCode filter layer X by <some SQL>` via `geoagent:filter_by_query` applies a visible filter
+- [ ] Export tool-call log captures LLM-driven calls alongside GUI-driven ones
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-review checklist
+
+Run through this before marking the plan complete:
+
+1. **Spec coverage.** The spec was: expose map tools as JupyterLab commands. All 10 non-skipped tools are registered (Task 4). `describedBy.args` is set (Task 4). Active panel is tracked so commands can find their target (Tasks 2, 6). Registration is wired into plugin activate (Task 5). Verified via chat (Task 8).
+
+2. **Placeholders.** None — every code step contains final code.
+
+3. **Type consistency.** `MapManagerAdapter` → used with `as any` cast in `commands.ts` (geo-agent types are `any`, intentional). `ActivePanel` interface fields (`controller`, `mcpClient`, `recorder`, `refresh`) match what `GeoAgentApp` supplies in Task 6. Command IDs spelled `geoagent:<tool_name>` consistently in Task 4 and Task 8.
+
+---
+
+## Execution handoff
+
+**Which approach?**
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task with review between them.
+2. **Inline Execution** — run tasks sequentially in this session with checkpoints after Tasks 3, 6, and 7.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -143,9 +143,11 @@ To go from your exploration to a full geo-agent web app (with LLM chat) in one s
 
 Alternatively, use **Export layers-input.json** alone and drop it into a [`geo-agent-template`](https://github.com/boettiger-lab/geo-agent-template) clone.
 
-### Use the AI chat panel (jupyter-ai)
+### Drive the map with the AI chat (jupyter-ai)
 
-jupyter-geoagent ships with jupyter-ai v3 and a pre-configured Claude persona that has access to the duckdb-geo MCP server. This lets you ask questions about catalog data and get answers written directly into notebooks, without leaving JupyterLab.
+jupyter-geoagent exposes every map tool as a JupyterLab command, so any jupyter-ai persona (Claude, OpenCode, Goose, …) can drive the map from the chat panel: show and hide layers, apply filters, restyle, fly to regions, and run SQL-driven filters through the DuckDB MCP server. The persona discovers the commands dynamically — no per-app prompt engineering required.
+
+**How it works, in one sentence.** jupyter-ai personas call the MCP tools `list_all_commands` / `execute_command` (from `jupyter_server_mcp` + `jupyterlab_commands_toolkit`), jupyter-geoagent registers each map tool as a command named `geoagent:<tool_name>` with a JSON-Schema `args` spec, and the LLM invokes them by name.
 
 **Setup (one time):**
 
@@ -158,15 +160,78 @@ jupyter-geoagent ships with jupyter-ai v3 and a pre-configured Claude persona th
      ]
    }
    ```
-2. Install the Claude ACP adapter: `npm install -g @zed-industries/claude-agent-acp --prefix ~/.local`
-3. Restart JupyterLab
+2. Install at least one ACP-based persona. Any of these works:
+   - **Claude:** `npm install -g @zed-industries/claude-agent-acp --prefix ~/.local`
+   - **OpenCode:** `curl -fsSL https://opencode.ai/install | bash`
+   - **Goose:** see [block.github.io/goose](https://block.github.io/goose/)
+3. Restart JupyterLab.
 
-**To chat:**
+**To start a chat:**
 
-1. Click the chat bubble icon in the JupyterLab left sidebar
-2. Click **+** to open a new chat
-3. Select the **Claude** persona
-4. Ask questions — the agent has access to duckdb-geo tools (`query`, `get_collection`, etc.) and can read/write notebooks
+1. Open a **GeoAgent Map** panel from the launcher (keep it open — the LLM operates on whichever panel is currently mounted).
+2. Click the chat bubble icon in the JupyterLab left sidebar.
+3. Click **+** for a new chat.
+4. Pick a persona (`@Claude`, `@OpenCode`, `@Goose`).
+
+#### Example 1: See what's available
+
+Prompt:
+
+> `@Claude use list_all_commands with query="geoagent:" and show the list with args schemas.`
+
+The response lists the registered commands, each with its argument schema:
+
+| Command ID | Args |
+|---|---|
+| `geoagent:show_layer` | `layer_id: string` |
+| `geoagent:hide_layer` | `layer_id: string` |
+| `geoagent:set_filter` | `layer_id: string`, `filter: array` |
+| `geoagent:clear_filter` | `layer_id: string` |
+| `geoagent:reset_filter` | `layer_id: string` |
+| `geoagent:set_style` | `layer_id: string`, `style: object` |
+| `geoagent:reset_style` | `layer_id: string` |
+| `geoagent:get_map_state` | *(none)* |
+| `geoagent:fly_to` | `center: [lon, lat]`, `zoom?: number` |
+| `geoagent:filter_by_query` | `layer_id: string`, `sql: string`, `id_property: string` |
+
+#### Example 2: Show, hide, and inspect a layer
+
+After adding a layer to the map from the catalog browser:
+
+> `@Claude call execute_command("geoagent:get_map_state", {}) and summarize the layers.`
+
+The LLM reports the current view (center, zoom) and per-layer state (`visible`, `opacity`, `filter`, `type`).
+
+> `@Claude hide the CAL FIRE layer, then show it again. Confirm the visible state at each step.`
+
+The map visually hides and re-shows the layer; the *Layers* tab checkbox updates automatically.
+
+#### Example 3: Filter by SQL
+
+The most powerful integration — the LLM writes a SQL query against the dataset's parquet, jupyter-geoagent aggregates matching IDs into a MapLibre `in` filter, and the map updates. IDs never pass through the LLM's context.
+
+> `@Claude the active layer is CAL FIRE prescribed burns. Use geoagent:filter_by_query to filter to rows where AGENCY = 'NPS'. CNG-processed datasets use "_cng_fid" as the id_property.`
+
+The LLM calls `get_stac_details` to look up the parquet path, writes a query like `SELECT _cng_fid FROM read_parquet('s3://...') WHERE AGENCY = 'NPS'`, then invokes `geoagent:filter_by_query` — the map filters to National Park Service burns only, and the LLM reports `idCount` (how many features matched) and `featuresInView` (how many are currently visible).
+
+#### Example 4: Restyle a layer
+
+> `@Claude color the burns by ASSISTUNIT using a match expression: USFS orange, NPS green, BLM brown, anything else grey.`
+
+The LLM builds a MapLibre data-driven paint expression and calls `geoagent:set_style` — the map recolors in place.
+
+#### Example 5: Guide the view
+
+> `@Claude fly to Yosemite Valley at zoom 12.`
+
+The LLM calls `geoagent:fly_to` with the correct lat/lon. Handy for setting up a specific framing before exporting the standalone app.
+
+#### Tips and gotchas
+
+- **Keep a panel open.** Commands target whichever GeoAgent Map panel was most recently mounted. If no panel is open, the LLM gets back *"No GeoAgent Map panel is open."*
+- **The LLM sees layer IDs, not display names.** If it picks the wrong layer, mention the `displayName` in your prompt — the tool descriptions already include a mapping from ID to displayName.
+- **LLM-driven actions are captured in the tool-call log.** Switch to the *Export* tab → **Export Tool Call Log** to get a JSON record alongside any GUI actions in the same session.
+- **`filter_by_query` requires an MCP connection.** Switch to the *Query* tab and click **Connect** first if the LLM reports *"filter_by_query requires an MCP connection."*
 
 ### Reproduce a session
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -57,6 +57,11 @@ export function registerGeoAgentCommands(app: JupyterFrontEnd): void {
         const tools = createMapTools(adapter as any, stubCatalog as any, panel.mcpClient ?? undefined);
         const tool = tools.find(t => t.name === meta.name);
         if (!tool) {
+          // map-tools.js only includes filter_by_query when mcpClient is truthy,
+          // so a missing tool here usually means the panel has no MCP connection.
+          if (meta.name === 'filter_by_query' && !panel.mcpClient) {
+            return JSON.stringify({ success: false, error: 'filter_by_query requires an MCP connection. Connect to the MCP server in the Query tab first.' });
+          }
           return JSON.stringify({ success: false, error: `Tool '${meta.name}' not found in createMapTools output.` });
         }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,82 @@
+/**
+ * Register one JupyterLab command per geo-agent map tool.
+ *
+ * Wiring:
+ *   app.commands.addCommand('geoagent:<tool_name>', { execute, describedBy })
+ *     → jupyter-ai persona calls execute_command (via jupyter_server_mcp MCP tool)
+ *     → jupyterlab_commands_toolkit emits a jupyterlab-command/v1 event
+ *     → the frontend event listener calls app.commands.execute('geoagent:<tool_name>', args)
+ *     → this handler looks up the active panel and dispatches through createMapTools()
+ *
+ * Call this once at plugin activation. Commands stay registered for the
+ * lifetime of the JupyterLab session; they error clearly if no panel is open.
+ */
+
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { createMapTools } from 'geo-agent/app/map-tools.js';
+import { MapManagerAdapter } from './core/map-manager-adapter';
+import { getActivePanel } from './core/active-panel';
+
+/** Skip tools that depend on machinery jupyter-geoagent doesn't provide yet. */
+const SKIP_TOOLS = new Set([
+  'list_datasets',          // needs DatasetCatalog; jupyter-geoagent uses MCP-backed catalog
+  'get_dataset_details',    // same
+  'set_projection',         // MapViewController doesn't implement globe/mercator toggle
+]);
+
+const NO_PANEL_ERROR = JSON.stringify({
+  success: false,
+  error: 'No GeoAgent Map panel is open. Ask the user to open one from the JupyterLab launcher (File → New → GeoAgent Map).',
+});
+
+export function registerGeoAgentCommands(app: JupyterFrontEnd): void {
+  // Build the tool list once using stubs — we only use each entry's name,
+  // description, and inputSchema here. Real mapManager/catalog/mcpClient are
+  // resolved inside each execute handler from getActivePanel().
+  const stubManager = { getLayerIds: () => [], getVectorLayerIds: () => [] };
+  const stubCatalog = { getAll: () => [], get: () => null, getIds: () => [] };
+  const stubMcp = {};
+  const toolMetadata = createMapTools(stubManager as any, stubCatalog as any, stubMcp as any);
+
+  for (const meta of toolMetadata) {
+    if (SKIP_TOOLS.has(meta.name)) continue;
+
+    const commandId = `geoagent:${meta.name}`;
+
+    app.commands.addCommand(commandId, {
+      label: `GeoAgent: ${meta.name}`,
+      caption: firstLine(meta.description),
+      describedBy: { args: meta.inputSchema },
+      execute: async (args) => {
+        const panel = getActivePanel();
+        if (!panel) return NO_PANEL_ERROR;
+
+        const adapter = new MapManagerAdapter(panel.controller, { onChange: panel.refresh });
+        // Rebuild the tool with the real adapter + mcpClient so closures bind
+        // to the current panel's state.
+        const tools = createMapTools(adapter as any, stubCatalog as any, panel.mcpClient ?? undefined);
+        const tool = tools.find(t => t.name === meta.name);
+        if (!tool) {
+          return JSON.stringify({ success: false, error: `Tool '${meta.name}' not found in createMapTools output.` });
+        }
+
+        const argsObj = (args ?? {}) as Record<string, any>;
+        try {
+          const result = await Promise.resolve(tool.execute(argsObj));
+          const resultStr = typeof result === 'string' ? result : JSON.stringify(result);
+          panel.recorder.record(meta.name, argsObj, resultStr);
+          return resultStr;
+        } catch (err: any) {
+          const errResult = JSON.stringify({ success: false, error: err?.message ?? String(err) });
+          panel.recorder.record(meta.name, argsObj, errResult);
+          return errResult;
+        }
+      },
+    });
+  }
+}
+
+function firstLine(s: string): string {
+  const idx = s.indexOf('\n');
+  return idx === -1 ? s : s.slice(0, idx);
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -50,6 +50,31 @@ export function registerGeoAgentCommands(app: JupyterFrontEnd): void {
       execute: async (args) => {
         const panel = getActivePanel();
         if (!panel) return NO_PANEL_ERROR;
+        const argsObj = (args ?? {}) as Record<string, any>;
+
+        // Route filter_by_query through our local implementation, which wraps
+        // array_agg in to_json() so DuckDB's MCP output is JSON-parseable.
+        // Upstream geo-agent has the same bug (uses bare array_agg); remove
+        // this branch once the upstream fix ships.
+        if (meta.name === 'filter_by_query') {
+          if (!panel.mcpClient) {
+            return recordAndReturn(panel, meta.name, argsObj,
+              { success: false, error: 'filter_by_query requires an MCP connection. Connect to the MCP server in the Query tab first.' });
+          }
+          try {
+            const result = await panel.controller.filterByQuery(
+              argsObj.layer_id,
+              argsObj.sql,
+              argsObj.id_property,
+              panel.mcpClient,
+            );
+            panel.refresh();
+            return recordAndReturn(panel, meta.name, argsObj, result);
+          } catch (err: any) {
+            return recordAndReturn(panel, meta.name, argsObj,
+              { success: false, error: err?.message ?? String(err) });
+          }
+        }
 
         const adapter = new MapManagerAdapter(panel.controller, { onChange: panel.refresh });
         // Rebuild the tool with the real adapter + mcpClient so closures bind
@@ -57,24 +82,18 @@ export function registerGeoAgentCommands(app: JupyterFrontEnd): void {
         const tools = createMapTools(adapter as any, stubCatalog as any, panel.mcpClient ?? undefined);
         const tool = tools.find(t => t.name === meta.name);
         if (!tool) {
-          // map-tools.js only includes filter_by_query when mcpClient is truthy,
-          // so a missing tool here usually means the panel has no MCP connection.
-          if (meta.name === 'filter_by_query' && !panel.mcpClient) {
-            return JSON.stringify({ success: false, error: 'filter_by_query requires an MCP connection. Connect to the MCP server in the Query tab first.' });
-          }
-          return JSON.stringify({ success: false, error: `Tool '${meta.name}' not found in createMapTools output.` });
+          return recordAndReturn(panel, meta.name, argsObj,
+            { success: false, error: `Tool '${meta.name}' not found in createMapTools output.` });
         }
 
-        const argsObj = (args ?? {}) as Record<string, any>;
         try {
           const result = await Promise.resolve(tool.execute(argsObj));
           const resultStr = typeof result === 'string' ? result : JSON.stringify(result);
           panel.recorder.record(meta.name, argsObj, resultStr);
           return resultStr;
         } catch (err: any) {
-          const errResult = JSON.stringify({ success: false, error: err?.message ?? String(err) });
-          panel.recorder.record(meta.name, argsObj, errResult);
-          return errResult;
+          return recordAndReturn(panel, meta.name, argsObj,
+            { success: false, error: err?.message ?? String(err) });
         }
       },
     });
@@ -84,4 +103,15 @@ export function registerGeoAgentCommands(app: JupyterFrontEnd): void {
 function firstLine(s: string): string {
   const idx = s.indexOf('\n');
   return idx === -1 ? s : s.slice(0, idx);
+}
+
+function recordAndReturn(
+  panel: NonNullable<ReturnType<typeof getActivePanel>>,
+  toolName: string,
+  args: Record<string, any>,
+  result: unknown,
+): string {
+  const resultStr = typeof result === 'string' ? result : JSON.stringify(result);
+  panel.recorder.record(toolName, args, resultStr);
+  return resultStr;
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,7 +20,7 @@ import { getActivePanel } from './core/active-panel';
 /** Skip tools that depend on machinery jupyter-geoagent doesn't provide yet. */
 const SKIP_TOOLS = new Set([
   'list_datasets',          // needs DatasetCatalog; jupyter-geoagent uses MCP-backed catalog
-  'get_dataset_details',    // same
+  'get_schema',             // same — delegates to catalog.get(dataset_id)
   'set_projection',         // MapViewController doesn't implement globe/mercator toggle
 ]);
 
@@ -33,7 +33,11 @@ export function registerGeoAgentCommands(app: JupyterFrontEnd): void {
   // Build the tool list once using stubs — we only use each entry's name,
   // description, and inputSchema here. Real mapManager/catalog/mcpClient are
   // resolved inside each execute handler from getActivePanel().
-  const stubManager = { getLayerIds: () => [], getVectorLayerIds: () => [] };
+  const stubManager = {
+    getLayerIds: () => [],
+    getVectorLayerIds: () => [],
+    getLayerSummaries: () => [],
+  };
   const stubCatalog = { getAll: () => [], get: () => null, getIds: () => [] };
   const stubMcp = {};
   const toolMetadata = createMapTools(stubManager as any, stubCatalog as any, stubMcp as any);
@@ -52,36 +56,18 @@ export function registerGeoAgentCommands(app: JupyterFrontEnd): void {
         if (!panel) return NO_PANEL_ERROR;
         const argsObj = (args ?? {}) as Record<string, any>;
 
-        // Route filter_by_query through our local implementation, which wraps
-        // array_agg in to_json() so DuckDB's MCP output is JSON-parseable.
-        // Upstream geo-agent has the same bug (uses bare array_agg); remove
-        // this branch once the upstream fix ships.
-        if (meta.name === 'filter_by_query') {
-          if (!panel.mcpClient) {
-            return recordAndReturn(panel, meta.name, argsObj,
-              { success: false, error: 'filter_by_query requires an MCP connection. Connect to the MCP server in the Query tab first.' });
-          }
-          try {
-            const result = await panel.controller.filterByQuery(
-              argsObj.layer_id,
-              argsObj.sql,
-              argsObj.id_property,
-              panel.mcpClient,
-            );
-            panel.refresh();
-            return recordAndReturn(panel, meta.name, argsObj, result);
-          } catch (err: any) {
-            return recordAndReturn(panel, meta.name, argsObj,
-              { success: false, error: err?.message ?? String(err) });
-          }
-        }
-
         const adapter = new MapManagerAdapter(panel.controller, { onChange: panel.refresh });
         // Rebuild the tool with the real adapter + mcpClient so closures bind
         // to the current panel's state.
         const tools = createMapTools(adapter as any, stubCatalog as any, panel.mcpClient ?? undefined);
         const tool = tools.find(t => t.name === meta.name);
         if (!tool) {
+          // map-tools.js only includes filter_by_query when mcpClient is truthy,
+          // so a missing tool here usually means the panel has no MCP connection.
+          if (meta.name === 'filter_by_query' && !panel.mcpClient) {
+            return recordAndReturn(panel, meta.name, argsObj,
+              { success: false, error: 'filter_by_query requires an MCP connection. Connect to the MCP server in the Query tab first.' });
+          }
           return recordAndReturn(panel, meta.name, argsObj,
             { success: false, error: `Tool '${meta.name}' not found in createMapTools output.` });
         }

--- a/src/components/GeoAgentApp.tsx
+++ b/src/components/GeoAgentApp.tsx
@@ -14,6 +14,7 @@ import { QueryPanel } from './QueryPanel';
 import { ExportPanel } from './ExportPanel';
 import { ToolCallRecorder } from '../core/tools';
 import { MCPClientWrapper } from '../core/mcp';
+import { setActivePanel } from '../core/active-panel';
 
 export interface GeoAgentAppProps {
   serverSettings: ServerConnection.ISettings;
@@ -57,6 +58,22 @@ export const GeoAgentApp: React.FC<GeoAgentAppProps> = ({
       .then(() => setMcpClient(client))
       .catch(e => console.warn('[GeoAgent] MCP connection failed:', e.message));
   }, [mcpServerUrl, mcpHeaders, useProxy, serverSettings]);
+
+  // Publish this panel as the active target for LLM-driven commands.
+  // Cleared on unmount so stale controllers don't get poked by the next
+  // opened panel.
+  React.useEffect(() => {
+    if (!mapController) return;
+    setActivePanel({
+      controller: mapController,
+      mcpClient,
+      recorder: recorderRef.current,
+      refresh: () => setLayerRefreshKey(k => k + 1),
+    });
+    return () => {
+      setActivePanel(null);
+    };
+  }, [mapController, mcpClient]);
 
   const handleDatasetAdded = React.useCallback((_datasetId: string, firstLayerId?: string) => {
     setLayerRefreshKey(k => k + 1);

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -298,7 +298,7 @@ export class MapViewController {
     idProperty: string,
     mcpClient: MCPClientWrapper,
   ): Promise<
-    | { success: true; idCount: number; message?: string }
+    | { success: true; idCount: number; featuresInView?: number; message?: string }
     | { success: false; error: string }
   > {
     const state = this.layers.get(layerId);
@@ -307,7 +307,7 @@ export class MapViewController {
     }
 
     const col = idProperty;
-    const wrappedSql = `SELECT array_agg("${col}") FILTER (WHERE "${col}" IS NOT NULL) FROM (${sql}) _filter_subquery`;
+    const wrappedSql = `SELECT to_json(array_agg("${col}") FILTER (WHERE "${col}" IS NOT NULL)) AS ids FROM (${sql}) _filter_subquery`;
 
     let rawResult: string;
     try {
@@ -340,12 +340,13 @@ export class MapViewController {
       };
     }
     if (!Array.isArray(ids) || ids.length === 0) {
-      return { success: true, idCount: 0, message: 'Query matched no features — filter not applied.' };
+      return { success: true, idCount: 0, featuresInView: 0, message: 'Query matched no features — filter not applied.' };
     }
 
     const filter: any[] = ['in', ['get', col], ['literal', ids]];
     this.setFilter(layerId, filter);
-    return { success: true, idCount: ids.length };
+    const featuresInView = this.map.queryRenderedFeatures({ layers: [layerId] }).length;
+    return { success: true, idCount: ids.length, featuresInView };
   }
 
   private _retileRaster(layerId: string): boolean {

--- a/src/core/active-panel.ts
+++ b/src/core/active-panel.ts
@@ -1,0 +1,31 @@
+/**
+ * Module-scoped reference to the currently active GeoAgent panel.
+ *
+ * Commands registered at plugin-activate time dereference this to find the
+ * panel to operate on. Panels set it on mount and clear it on unmount.
+ * Multi-panel UX: last-mounted wins — matches the ArcGIS "active frame"
+ * idiom. (If both panels are open, the LLM operates on whichever was most
+ * recently shown.)
+ */
+
+import type { MapViewController } from '../components/MapView';
+import type { MCPClientWrapper } from './mcp';
+import type { ToolCallRecorder } from './tools';
+
+export interface ActivePanel {
+  controller: MapViewController;
+  mcpClient: MCPClientWrapper | null;
+  recorder: ToolCallRecorder;
+  /** Called after any tool mutation so React panels re-render. */
+  refresh: () => void;
+}
+
+let current: ActivePanel | null = null;
+
+export function setActivePanel(panel: ActivePanel | null): void {
+  current = panel;
+}
+
+export function getActivePanel(): ActivePanel | null {
+  return current;
+}

--- a/src/core/map-manager-adapter.ts
+++ b/src/core/map-manager-adapter.ts
@@ -1,0 +1,156 @@
+/**
+ * Adapter that exposes MapViewController through the MapManager surface
+ * expected by geo-agent/app/map-tools.js createMapTools().
+ *
+ * Two translations happen here:
+ *   1. Return shapes: MapViewController returns booleans; MapManager tools
+ *      expect { success: true, layer, ... } on success, { success: false,
+ *      error: "..." } on failure (with helpful "Available: a, b, c" hints).
+ *   2. Method names: getMapState (not getViewState), syncCheckbox (which
+ *      becomes a UI-refresh trigger).
+ */
+
+import type { MapViewController } from '../components/MapView';
+
+export interface MapManagerAdapterOptions {
+  /** Called after any state-mutating operation so React panels re-render. */
+  onChange?: () => void;
+}
+
+export class MapManagerAdapter {
+  constructor(
+    private controller: MapViewController,
+    private options: MapManagerAdapterOptions = {},
+  ) {}
+
+  // --- layer id enumerations (used by tool descriptions) ---
+
+  getLayerIds(): string[] {
+    return [...this.controller.layers.keys()];
+  }
+
+  getVectorLayerIds(): string[] {
+    return [...this.controller.layers.entries()]
+      .filter(([, s]) => s.type === 'vector')
+      .map(([id]) => id);
+  }
+
+  // --- show / hide ---
+
+  showLayer(layerId: string) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) {
+      return { success: false, error: `Unknown layer: ${layerId}. Available: ${this.getLayerIds().join(', ') || '(none)'}` };
+    }
+    this.controller.showLayer(layerId);
+    this.options.onChange?.();
+    return { success: true, layer: layerId, displayName: state.displayName, visible: true };
+  }
+
+  hideLayer(layerId: string) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) {
+      return { success: false, error: `Unknown layer: ${layerId}. Available: ${this.getLayerIds().join(', ') || '(none)'}` };
+    }
+    this.controller.hideLayer(layerId);
+    this.options.onChange?.();
+    return { success: true, layer: layerId, displayName: state.displayName, visible: false };
+  }
+
+  // --- filter ---
+
+  setFilter(layerId: string, filter: any) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+    if (state.type !== 'vector') return { success: false, error: `Layer '${layerId}' is raster — filtering only works on vector layers` };
+
+    if (filter === null || filter === undefined) {
+      this.controller.clearFilter(layerId);
+    } else {
+      this.controller.setFilter(layerId, filter);
+    }
+    this.options.onChange?.();
+
+    const features = this.controller.map.queryRenderedFeatures({ layers: [layerId] });
+    const result: any = {
+      success: true,
+      layer: layerId,
+      displayName: state.displayName,
+      filter: filter ?? null,
+      featuresInView: features.length,
+    };
+    if (filter && features.length === 0) {
+      result.warning = 'No features match this filter in the current view. Filter may be too restrictive or property values may not match. Use filter_by_query to verify via SQL.';
+    }
+    return result;
+  }
+
+  clearFilter(layerId: string) {
+    return this.setFilter(layerId, null);
+  }
+
+  resetFilter(layerId: string) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+    return this.setFilter(layerId, state.defaultFilter ?? null);
+  }
+
+  // --- style ---
+
+  setStyle(layerId: string, paintProps: Record<string, any>) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+
+    const updates: Array<{ property: string; success: boolean; error?: string }> = [];
+    for (const [prop, value] of Object.entries(paintProps)) {
+      try {
+        this.controller.setStyle(layerId, { [prop]: value });
+        updates.push({ property: prop, success: true });
+      } catch (err: any) {
+        updates.push({ property: prop, success: false, error: err.message });
+      }
+    }
+    this.options.onChange?.();
+    return { success: true, layer: layerId, displayName: state.displayName, updates };
+  }
+
+  resetStyle(layerId: string) {
+    const state = this.controller.layers.get(layerId);
+    if (!state) return { success: false, error: `Unknown layer: ${layerId}` };
+    this.controller.resetStyle(layerId);
+    this.options.onChange?.();
+    return { success: true, layer: layerId, displayName: state.displayName };
+  }
+
+  // --- view ---
+
+  flyTo({ center, zoom }: { center: [number, number]; zoom?: number }) {
+    this.controller.flyTo(center, zoom);
+    return { success: true, center, zoom: zoom ?? this.controller.map.getZoom() };
+  }
+
+  getMapState() {
+    const layers: Record<string, any> = {};
+    for (const [id, state] of this.controller.layers) {
+      layers[id] = {
+        displayName: state.displayName,
+        type: state.type,
+        visible: state.visible,
+        opacity: state.opacity,
+        filter: state.filter ?? null,
+      };
+    }
+    const view = this.controller.getViewState();
+    return { success: true, view, layers };
+  }
+
+  // --- no-op on our side; geo-agent's tool code calls this to sync a legacy DOM checkbox ---
+  syncCheckbox(_layerId: string): void {
+    this.options.onChange?.();
+  }
+
+  // setProjection not supported yet — see plan non-goals.
+  setProjection(_type: string) {
+    return { success: false, error: 'Projection switching is not yet implemented in jupyter-geoagent.' };
+  }
+}

--- a/src/core/map-manager-adapter.ts
+++ b/src/core/map-manager-adapter.ts
@@ -80,7 +80,7 @@ export class MapManagerAdapter {
       featuresInView: features.length,
     };
     if (filter && features.length === 0) {
-      result.warning = 'No features match this filter in the current view. Filter may be too restrictive or property values may not match. Use filter_by_query to verify via SQL.';
+      result.warning = 'No features match this filter in the current view. Filter may be too restrictive or property values may not match; if the layer was just added or the map was just flown to a new region, tiles may not have loaded yet — wait a moment and re-check. Use filter_by_query to verify via SQL.';
     }
     return result;
   }
@@ -111,7 +111,14 @@ export class MapManagerAdapter {
       }
     }
     this.options.onChange?.();
-    return { success: true, layer: layerId, displayName: state.displayName, updates };
+    const anySucceeded = updates.length === 0 || updates.some(u => u.success);
+    return {
+      success: anySucceeded,
+      layer: layerId,
+      displayName: state.displayName,
+      updates,
+      ...(anySucceeded ? {} : { error: 'All style properties failed to apply; see updates[].error' }),
+    };
   }
 
   resetStyle(layerId: string) {
@@ -125,6 +132,7 @@ export class MapManagerAdapter {
   // --- view ---
 
   flyTo({ center, zoom }: { center: [number, number]; zoom?: number }) {
+    // No onChange: camera motion doesn't affect Layer/Style panel state.
     this.controller.flyTo(center, zoom);
     return { success: true, center, zoom: zoom ?? this.controller.map.getZoom() };
   }
@@ -144,7 +152,11 @@ export class MapManagerAdapter {
     return { success: true, view, layers };
   }
 
-  // --- no-op on our side; geo-agent's tool code calls this to sync a legacy DOM checkbox ---
+  // geo-agent's tool code calls this after show/hide to update a legacy DOM
+  // checkbox. In jupyter-geoagent the React Layers panel re-renders on
+  // onChange, so this is the bridge that keeps it in sync. Note that
+  // showLayer/hideLayer already fire onChange themselves; the duplicate
+  // call here is idempotent (React batches re-renders).
   syncCheckbox(_layerId: string): void {
     this.options.onChange?.();
   }

--- a/src/core/map-manager-adapter.ts
+++ b/src/core/map-manager-adapter.ts
@@ -35,6 +35,15 @@ export class MapManagerAdapter {
       .map(([id]) => id);
   }
 
+  /** Upstream geo-agent tools call this instead of getLayerIds/getVectorLayerIds. */
+  getLayerSummaries(): Array<{ id: string; displayName: string; type: 'vector' | 'raster' }> {
+    return [...this.controller.layers.entries()].map(([id, state]) => ({
+      id,
+      displayName: state.displayName,
+      type: state.type,
+    }));
+  }
+
   // --- show / hide ---
 
   showLayer(layerId: string) {

--- a/src/core/tool-metadata.ts
+++ b/src/core/tool-metadata.ts
@@ -31,6 +31,12 @@ export function getToolMetadata(
       [...controller.layers.entries()]
         .filter(([, s]) => s.type === 'vector')
         .map(([id]) => id),
+    getLayerSummaries: () =>
+      [...controller.layers.entries()].map(([id, state]) => ({
+        id,
+        displayName: state.displayName,
+        type: state.type,
+      })),
   };
   const catalogStub = { getAll: () => [], get: () => null, getIds: () => [] };
   // Pass a truthy stub so filter_by_query metadata is included.

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { ILauncher } from '@jupyterlab/launcher';
 import { WidgetTracker } from '@jupyterlab/apputils';
 import { LabIcon } from '@jupyterlab/ui-components';
 import { GeoAgentPanel } from './panel';
+import { registerGeoAgentCommands } from './commands';
 import geoagentIconSvg from '../style/geoagent-icon.svg';
 
 const geoagentIcon = new LabIcon({
@@ -45,6 +46,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     restorer: ILayoutRestorer | null,
   ) => {
     console.log('jupyter-geoagent extension activated');
+    registerGeoAgentCommands(app);
 
     const tracker = new WidgetTracker<GeoAgentPanel>({ namespace: 'geoagent' });
 

--- a/src/typings/geo-agent.d.ts
+++ b/src/typings/geo-agent.d.ts
@@ -36,6 +36,6 @@ declare module 'geo-agent/app/map-tools.js' {
     name: string;
     description: string;
     inputSchema: any;
-    execute: (args: Record<string, any>) => any;
+    execute: (args: Record<string, any>) => any | Promise<any>;
   }>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,8 +2164,8 @@ __metadata:
 
 "geo-agent@git+https://github.com/boettiger-lab/geo-agent.git":
   version: 1.0.0
-  resolution: "geo-agent@https://github.com/boettiger-lab/geo-agent.git#commit=6f492038781fb4ecd583f4dd30cd672cabbff106"
-  checksum: 27b60c7e7146abebfa05700f164f0a9f1a41c2fadd1164d9bb214ae2b862725dc796cbb428b1be5a9a6c87e1fcee24a7701059c68c48f2f3f719f18664dd7e11
+  resolution: "geo-agent@https://github.com/boettiger-lab/geo-agent.git#commit=bd724a52c7e42d95de713c0d063d84ecd7074003"
+  checksum: bade973c6243ef99cc80ad6b297927427ffa45c92948e3742c25393464de3f83f9c7faba5607c1e2a0d5b3223ad843e834d1d47e2e60365194f839448529fcdb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Expose every map tool as a JupyterLab command so jupyter-ai personas (Claude, OpenCode, Goose, …) can drive the map from the chat panel — show/hide layers, set filters, restyle, fly to regions, and run SQL-driven filters via DuckDB MCP. The persona discovers commands dynamically via `list_all_commands`; no per-app prompt engineering is needed.

**How the chain works:** jupyter-ai persona → `execute_command` MCP tool (`jupyter_server_mcp`) → `jupyterlab_commands_toolkit` emits a frontend event → `app.commands.execute('geoagent:<tool>', args)` → our handler constructs `MapManagerAdapter(controller, {onChange: refresh})` → dispatches through geo-agent's `createMapTools()`.

## What's in the PR

- **`src/commands.ts`** — at plugin activation, registers one `geoagent:<tool_name>` command per tool with `describedBy.args` set to the tool's JSON-Schema `inputSchema`. Skips `list_datasets` / `get_schema` (need the geo-agent `DatasetCatalog` we don't ship) and `set_projection` (no globe/mercator toggle yet).
- **`src/core/map-manager-adapter.ts`** — `MapManagerAdapter` wraps `MapViewController` with the `MapManager` surface geo-agent expects (`{success, ...}` return shapes, `getLayerSummaries`, `syncCheckbox`). Every mutation fires `options.onChange`, which bumps `layerRefreshKey` so the *Layers* panel re-renders after LLM-driven changes.
- **`src/core/active-panel.ts`** — module-scoped ref `{controller, mcpClient, recorder, refresh}` that `GeoAgentApp` updates on mount and clears on unmount. Multi-panel UX is last-mounted-wins (ArcGIS "active frame" idiom).
- **Adapted to upstream geo-agent bump** (`bd724a52`) which renamed `getLayerIds`/`getVectorLayerIds` → `getLayerSummaries`, renamed `get_dataset_details` → `get_schema`, and added `to_json()` wrapping around `array_agg` in `filter_by_query` (fixed upstream via boettiger-lab/geo-agent#180).
- **Docs** — `docs/usage.md` gains *"Drive the map with the AI chat"* with five worked examples and a tips/gotchas block; `docs/design.md` gets a *"jupyter-ai Command Bridge"* section documenting the event chain.

## Verified in a live session

Driven by `@Claude` in a jupyter-ai chat, pointed at the CAL FIRE and PAD-US layers:

- [x] `list_all_commands` with `query="geoagent:"` returns 10 commands with their args schemas
- [x] `geoagent:get_map_state` returns current view + per-layer state
- [x] `geoagent:hide_layer` / `geoagent:show_layer` — map toggles, Layers tab checkbox syncs
- [x] `geoagent:filter_by_query` on PAD-US `Mang_Name = 'NPS'` — 509 matches, 1,842 features in view
- [x] Tool-call log captures every LLM-driven call alongside GUI actions

## Related

- Upstream fix: boettiger-lab/geo-agent#180 (merged) — wraps `array_agg` in `to_json()` so DuckDB MCP output is JSON-parseable

## Follow-ups

- Re-enable `list_datasets` / `get_schema` once jupyter-geoagent ships an MCP-backed catalog that implements the `DatasetCatalog` surface
- Add `set_projection` once `MapViewController` supports a globe/mercator toggle
- Consider a Python wrapper under the `jupyter_server_mcp.tools` entry-point for friendlier tool names (`show_layer` vs. `execute_command("geoagent:show_layer", …)`)