### PR TITLE
Expose full geo-agent tool descriptions to jupyter-ai via usage field

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -50,6 +50,11 @@ export function registerGeoAgentCommands(app: JupyterFrontEnd): void {
     app.commands.addCommand(commandId, {
       label: `GeoAgent: ${meta.name}`,
       caption: firstLine(meta.description),
+      // `usage` is what jupyterlab_commands_toolkit surfaces as `description`
+      // in list_all_commands output, so the LLM sees the full tool description
+      // (including nudges like "IMPORTANT: check featuresInView" and available
+      // layer lists), not just the one-line caption.
+      usage: meta.description,
       describedBy: { args: meta.inputSchema },
       execute: async (args) => {
         const panel = getActivePanel();


### PR DESCRIPTION
## Summary

One-line fix so jupyter-ai personas see the **full** tool description (not just the first line) when they call `list_all_commands`.

## The bug

`jupyterlab_commands_toolkit.list_all_commands` reads JupyterLab's `usage` field and emits it as `description` in the LLM-facing payload. Our command registrar set `caption: firstLine(meta.description)` but didn't set `usage`, so the LLM only ever saw the first line of each tool's docs — dropping the *"IMPORTANT: check featuresInView"*, *"use match not legacy in"*, pickLayerNudge, available-layer lists, and any "prefer this over exporting data" guidance the geo-agent authors included.

This was the likely cause of a recent session where a persona defaulted to *"let me export features as GeoJSON"* instead of using `geoagent:set_filter` on an already-loaded PMTiles layer.

## The fix

Add `usage: meta.description` alongside the existing `caption: firstLine(...)`. Caption stays terse (for JupyterLab's own tooltip UI); usage carries the full text.

## Test plan

- [ ] `@Claude use list_all_commands with query="geoagent:" and show me the full `description` field for `geoagent:set_filter`` — the response should include the MapLibre syntax guidance and IMPORTANT notes, not just *"Apply a MapLibre filter expression to a vector layer."*
- [ ] Re-run the *"show national parks in California"* prompt on an open PMTiles layer and confirm the persona reaches for `geoagent:set_filter` directly.