### PR TITLE
Add geoagent:add_layer command for chat-driven layer addition

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -107,25 +107,37 @@ export function registerGeoAgentCommands(app: JupyterFrontEnd): void {
 function registerAddLayerCommand(app: JupyterFrontEnd): void {
   app.commands.addCommand('geoagent:add_layer', {
     label: 'GeoAgent: add_layer',
-    caption: 'Add a STAC asset (PMTiles or COG) to the map as a live interactive layer.',
+    caption: 'Add a STAC asset (PMTiles or COG) to the map as a live interactive layer, optionally with a default style/filter.',
     usage: `Add a STAC asset from the configured catalog as a live interactive map layer (PMTiles vector or COG raster). This is the correct way to bring a dataset onto the map when the user asks you to "add X" or "show X" — do NOT write config files, export GeoJSON, or otherwise materialize the data client-side.
 
 Workflow:
 1. Use browse_stac_catalog (MCP) to find a collection_id.
 2. Use get_collection (MCP) to see which assets are available — PMTiles assets typically have href ending in .pmtiles, COG raster assets have href ending in .tif / .tiff.
-3. Call this command with the collection_id and asset_id. The command returns the layer_id you can use in subsequent set_filter / set_style / filter_by_query / show_layer / hide_layer calls.
+3. Call this command with the collection_id and asset_id, plus any of the optional style/filter overrides. The command returns the layer_id you can use in subsequent set_filter / set_style / filter_by_query / show_layer / hide_layer calls.
 
 After adding, the map flies to the collection's extent and the layer is visible.
 
-Parameters:
+Required parameters:
 - collection_id: the STAC collection ID (e.g., 'fire-perimeters')
-- asset_id: the visual asset key inside the collection (e.g., 'firep-pmtiles')`,
+- asset_id: the visual asset key inside the collection (e.g., 'firep-pmtiles')
+
+Optional parameters (mirror the layers-input.json schema so you can compose a full styled layer in a single call):
+- title: display name for the Layers panel (defaults to the STAC asset title)
+- source_layer: PMTiles source-layer name (defaults to the asset's first 'vector:layers' entry, falling back to collection_id)
+- default_style: MapLibre paint properties for the fill/raster layer, e.g. {"fill-color": "#FF6B35", "fill-opacity": 0.5}
+- outline_style: MapLibre paint properties for the polygon outline line, e.g. {"line-color": "#D32F2F", "line-width": 1}. Only meaningful for vector polygon layers; ignored otherwise.
+- default_filter: MapLibre filter expression applied on load, e.g. [">=", ["get", "YEAR_"], 2000]. Use the modern expression form ["==", ["get", "PROP"], VAL], not legacy ["==", "PROP", VAL].`,
     describedBy: {
       args: {
         type: 'object',
         properties: {
           collection_id: { type: 'string', description: 'STAC collection ID' },
           asset_id: { type: 'string', description: 'Visual asset key (PMTiles vector or COG raster)' },
+          title: { type: 'string', description: 'Display name shown in the Layers panel (defaults to the asset title)' },
+          source_layer: { type: 'string', description: 'PMTiles source-layer name; defaults to the asset\'s first vector:layers entry' },
+          default_style: { type: 'object', description: 'MapLibre paint properties for the fill/raster layer' },
+          outline_style: { type: 'object', description: 'MapLibre paint properties for the polygon outline line layer (vector polygons only)' },
+          default_filter: { type: 'array', description: 'MapLibre filter expression applied on load' },
         },
         required: ['collection_id', 'asset_id'],
       },
@@ -172,6 +184,15 @@ Parameters:
         return recordAndReturn(panel, 'add_layer', argsObj,
           { success: false, error: `Asset '${assetId}' is not a visual type. add_layer only supports PMTiles (vector) or COG (raster) assets.` });
       }
+
+      // Merge LLM-supplied overrides into the config before addLayer.
+      // Matches the layers-input.json schema so the LLM can compose a
+      // fully-styled layer in one call.
+      if (typeof argsObj.title === 'string') config.title = argsObj.title;
+      if (typeof argsObj.source_layer === 'string') config.sourceLayer = argsObj.source_layer;
+      if (argsObj.default_style && typeof argsObj.default_style === 'object') config.defaultStyle = argsObj.default_style;
+      if (argsObj.outline_style && typeof argsObj.outline_style === 'object') config.outlineStyle = argsObj.outline_style;
+      if (Array.isArray(argsObj.default_filter)) config.defaultFilter = argsObj.default_filter;
 
       const columns = extractColumns(parsed);
       const layerId = panel.controller.addLayer(collectionId, config, columns);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -16,6 +16,7 @@ import { JupyterFrontEnd } from '@jupyterlab/application';
 import { createMapTools } from 'geo-agent/app/map-tools.js';
 import { MapManagerAdapter } from './core/map-manager-adapter';
 import { getActivePanel } from './core/active-panel';
+import { assetToMapLayerConfig, extractColumns, MCPCollection } from './core/mcp-catalog';
 
 /** Skip tools that depend on machinery jupyter-geoagent doesn't provide yet. */
 const SKIP_TOOLS = new Set([
@@ -89,6 +90,105 @@ export function registerGeoAgentCommands(app: JupyterFrontEnd): void {
       },
     });
   }
+
+  registerAddLayerCommand(app);
+}
+
+/**
+ * `geoagent:add_layer` — jupyter-geoagent-specific command (not part of the
+ * geo-agent tool set). Fetches a STAC asset via MCP `get_collection` and adds
+ * it to the map as a live PMTiles/COG layer, equivalent to clicking
+ * "Add to Map" in the catalog browser.
+ *
+ * Needed because geo-agent web apps have their layers pre-configured at
+ * deploy time, but in jupyter-geoagent the user expects to compose the map
+ * interactively — so the LLM needs an addable-layer path too.
+ */
+function registerAddLayerCommand(app: JupyterFrontEnd): void {
+  app.commands.addCommand('geoagent:add_layer', {
+    label: 'GeoAgent: add_layer',
+    caption: 'Add a STAC asset (PMTiles or COG) to the map as a live interactive layer.',
+    usage: `Add a STAC asset from the configured catalog as a live interactive map layer (PMTiles vector or COG raster). This is the correct way to bring a dataset onto the map when the user asks you to "add X" or "show X" — do NOT write config files, export GeoJSON, or otherwise materialize the data client-side.
+
+Workflow:
+1. Use browse_stac_catalog (MCP) to find a collection_id.
+2. Use get_collection (MCP) to see which assets are available — PMTiles assets typically have href ending in .pmtiles, COG raster assets have href ending in .tif / .tiff.
+3. Call this command with the collection_id and asset_id. The command returns the layer_id you can use in subsequent set_filter / set_style / filter_by_query / show_layer / hide_layer calls.
+
+After adding, the map flies to the collection's extent and the layer is visible.
+
+Parameters:
+- collection_id: the STAC collection ID (e.g., 'fire-perimeters')
+- asset_id: the visual asset key inside the collection (e.g., 'firep-pmtiles')`,
+    describedBy: {
+      args: {
+        type: 'object',
+        properties: {
+          collection_id: { type: 'string', description: 'STAC collection ID' },
+          asset_id: { type: 'string', description: 'Visual asset key (PMTiles vector or COG raster)' },
+        },
+        required: ['collection_id', 'asset_id'],
+      },
+    },
+    execute: async (args) => {
+      const panel = getActivePanel();
+      if (!panel) return NO_PANEL_ERROR;
+      const argsObj = (args ?? {}) as Record<string, any>;
+
+      if (!panel.mcpClient) {
+        return recordAndReturn(panel, 'add_layer', argsObj,
+          { success: false, error: 'add_layer requires an MCP connection. Connect to the MCP server in the Query tab first.' });
+      }
+
+      const collectionId = argsObj.collection_id;
+      const assetId = argsObj.asset_id;
+      if (!collectionId || !assetId) {
+        return recordAndReturn(panel, 'add_layer', argsObj,
+          { success: false, error: 'Both collection_id and asset_id are required.' });
+      }
+
+      let parsed: MCPCollection;
+      try {
+        const raw = await panel.mcpClient.callTool('get_collection', { collection_id: collectionId });
+        parsed = typeof raw === 'string' ? JSON.parse(raw) : (raw as MCPCollection);
+      } catch (err: any) {
+        return recordAndReturn(panel, 'add_layer', argsObj,
+          { success: false, error: `Failed to fetch collection '${collectionId}': ${err?.message ?? String(err)}` });
+      }
+      if ((parsed as any).error) {
+        return recordAndReturn(panel, 'add_layer', argsObj,
+          { success: false, error: `Collection '${collectionId}' not found: ${(parsed as any).error}` });
+      }
+
+      const asset = parsed.assets?.[assetId];
+      if (!asset) {
+        const available = Object.keys(parsed.assets || {}).join(', ') || '(none)';
+        return recordAndReturn(panel, 'add_layer', argsObj,
+          { success: false, error: `Asset '${assetId}' not found in collection '${collectionId}'. Available assets: ${available}` });
+      }
+
+      const config = assetToMapLayerConfig(collectionId, assetId, asset, panel.s3Endpoint, panel.titilerUrl);
+      if (!config) {
+        return recordAndReturn(panel, 'add_layer', argsObj,
+          { success: false, error: `Asset '${assetId}' is not a visual type. add_layer only supports PMTiles (vector) or COG (raster) assets.` });
+      }
+
+      const columns = extractColumns(parsed);
+      const layerId = panel.controller.addLayer(collectionId, config, columns);
+      panel.controller.showLayer(layerId);
+
+      // Fly to the collection's extent so the user immediately sees it.
+      const bbox = parsed.extent?.spatial?.bbox?.[0];
+      if (bbox) {
+        const [west, south, east, north] = bbox;
+        panel.controller.flyTo([(west + east) / 2, (south + north) / 2]);
+      }
+
+      panel.refresh();
+      return recordAndReturn(panel, 'add_layer', argsObj,
+        { success: true, layer_id: layerId, ...(bbox ? { bbox } : {}) });
+    },
+  });
 }
 
 function firstLine(s: string): string {

--- a/src/components/GeoAgentApp.tsx
+++ b/src/components/GeoAgentApp.tsx
@@ -15,6 +15,7 @@ import { ExportPanel } from './ExportPanel';
 import { ToolCallRecorder } from '../core/tools';
 import { MCPClientWrapper } from '../core/mcp';
 import { setActivePanel } from '../core/active-panel';
+import { deriveS3Endpoint } from '../core/mcp-catalog';
 
 export interface GeoAgentAppProps {
   serverSettings: ServerConnection.ISettings;
@@ -69,11 +70,13 @@ export const GeoAgentApp: React.FC<GeoAgentAppProps> = ({
       mcpClient,
       recorder: recorderRef.current,
       refresh: () => setLayerRefreshKey(k => k + 1),
+      s3Endpoint: deriveS3Endpoint(defaultCatalogUrl),
+      titilerUrl,
     });
     return () => {
       setActivePanel(null);
     };
-  }, [mapController, mcpClient]);
+  }, [mapController, mcpClient, defaultCatalogUrl, titilerUrl]);
 
   const handleDatasetAdded = React.useCallback((_datasetId: string, firstLayerId?: string) => {
     setLayerRefreshKey(k => k + 1);

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -97,17 +97,27 @@ export class MapViewController {
       this.map.addLayer(layerDef);
 
       const outlineId = `${layerId}-outline`;
+      const outlinePaint: Record<string, any> = config.outlineStyle
+        ? { ...config.outlineStyle }
+        : { 'line-color': '#333', 'line-width': 0.5, 'line-opacity': 0.5 };
       const outlineDef: maplibregl.LayerSpecification = {
         id: outlineId,
         type: 'line',
         source: sourceId,
-        paint: { 'line-color': '#333', 'line-width': 0.5, 'line-opacity': 0.5 },
+        paint: outlinePaint as any,
         layout: { visibility: config.defaultVisible ? 'visible' : 'none' },
       };
       if (config.sourceLayer && config.sourceType !== 'geojson') {
         (outlineDef as any)['source-layer'] = config.sourceLayer;
       }
       this.map.addLayer(outlineDef);
+
+      // Apply defaultFilter at add time — otherwise it's only stored in
+      // LayerState and the rendered tiles show unfiltered features.
+      if (config.defaultFilter) {
+        this.map.setFilter(layerId, config.defaultFilter as any);
+        this.map.setFilter(outlineId, config.defaultFilter as any);
+      }
 
     } else if (config.layerType === 'raster') {
       let tilesUrl = `${this.titilerUrl}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=${encodeURIComponent(config.cogUrl!)}`;

--- a/src/core/active-panel.ts
+++ b/src/core/active-panel.ts
@@ -18,6 +18,10 @@ export interface ActivePanel {
   recorder: ToolCallRecorder;
   /** Called after any tool mutation so React panels re-render. */
   refresh: () => void;
+  /** HTTPS origin used to resolve `s3://` hrefs when adding STAC assets. */
+  s3Endpoint: string;
+  /** TiTiler base URL for COG raster tile URLs. */
+  titilerUrl: string;
 }
 
 let current: ActivePanel | null = null;


### PR DESCRIPTION
## Summary

Adds `geoagent:add_layer` — the missing piece for chat-driven map composition. Without it, asking a persona *"add CalFire wildfires to the map"* produced the wrong behaviour: the LLM fell back on editing `layers-input` config files and told the user to reload the app.

## The gap

The command set derived from `createMapTools` only covers **existing** layers (`show_layer`, `hide_layer`, `set_filter`, `set_style`, `filter_by_query`, …). That's correct for the geo-agent web app, where layers are pre-configured at deploy time and the LLM shouldn't invent new ones. But in jupyter-geoagent the *whole point* is interactive composition — the GUI has an *"Add to Map"* button, and the chat needs an equivalent.

## What this adds

- **`geoagent:add_layer`** with args `{collection_id, asset_id}`. Fetches the collection via MCP `get_collection`, resolves the asset to a `MapLayerConfig`, calls `controller.addLayer` + `showLayer` + `flyTo`. Returns the `layer_id` the LLM can use in follow-up calls.
- **Reuses existing pure helpers** in `src/core/mcp-catalog.ts` (`assetToMapLayerConfig`, `extractColumns`, `deriveS3Endpoint`) — same code path as the GUI's *Add to Map* button.
- **`ActivePanel` gets `s3Endpoint` + `titilerUrl`** so the command can resolve `s3://` hrefs and build COG tile URLs without prop drilling. `GeoAgentApp` derives `s3Endpoint` from `defaultCatalogUrl`.
- **Usage text is deliberately prescriptive:** "This is the correct way to bring a dataset onto the map — do NOT write config files, export GeoJSON, or otherwise materialize the data client-side." Steers the persona away from its default materialize-the-data instinct (now visible via `list_all_commands` thanks to #9).

## Test plan

- [ ] `@Claude add CalFire wildfire perimeters to the map` — persona calls `browse_stac_catalog` / `get_collection`, then `geoagent:add_layer("fire-perimeters", "firep-pmtiles")`. Map shows the layer, flies to California, Layers tab lists it.
- [ ] `@Claude show Protected Areas Database` on a different collection — persona finds the right PMTiles asset and adds it.
- [ ] Missing asset → command returns `{success: false, error: "Asset 'X' not found in collection 'Y'. Available assets: …"}`.
- [ ] Non-visual asset (parquet) → command returns *"add_layer only supports PMTiles (vector) or COG (raster) assets."*
- [ ] Follow-up `geoagent:set_filter` on the returned `layer_id` works as expected.