### PR TITLE
Build a minimal JupyterHub container image in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: Build container image
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: docker
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,48 @@
+# Minimal JupyterHub single-user image with jupyter-geoagent and
+# jupyter-ai (Claude + OpenCode ACP personas) pre-installed.
+#
+# Base: quay.io/jupyter/minimal-notebook — Ubuntu-based Jupyter Server
+# with Python, JupyterLab 4, git/curl/bash utilities, NB_USER=jovyan,
+# NB_UID=1000. Intended for JupyterHub single-user pods.
+FROM quay.io/jupyter/minimal-notebook:latest
+
+USER root
+
+# Node.js + npm are required for the @zed-industries/claude-agent-acp
+# bridge that jupyter-ai spawns when the user @mentions @Claude.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends nodejs npm && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Claude Code CLI. The installer drops a versioned binary tree under
+# $HOME/.local/share/claude/versions/<ver>/ and a symlink at
+# $HOME/.local/bin/claude pointing to it. For a system-wide install
+# that survives JupyterHub home-volume mounts, move the whole tree to
+# /opt/claude and retarget the /usr/local/bin/claude symlink.
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    CLAUDE_TARGET="$(readlink "$HOME/.local/bin/claude")" && \
+    mv "$HOME/.local/share/claude" /opt/claude && \
+    ln -sf "${CLAUDE_TARGET/$HOME\/.local\/share\/claude/\/opt\/claude}" /usr/local/bin/claude && \
+    rm -rf "$HOME/.local"
+
+# OpenCode CLI — used by the jupyter-ai OpenCode persona.
+RUN curl -fsSL https://opencode.ai/install | bash && \
+    mv "$HOME/.opencode/bin/opencode" /usr/local/bin/opencode && \
+    rm -rf "$HOME/.opencode"
+
+# Claude ACP bridge — installs a `claude-agent-acp` binary onto PATH.
+RUN npm install -g @zed-industries/claude-agent-acp && \
+    npm cache clean --force
+
+# jupyter-ai v3 transitively pulls jupyter-ai-acp-client,
+# jupyter-ai-chat-commands, and jupyter-ai-persona-manager, which
+# register the Claude / OpenCode / Goose personas automatically.
+# jupyter-geoagent registers the GeoAgent Map launcher tile plus
+# `geoagent:*` JupyterLab commands so the LLM personas can drive the
+# map directly from chat.
+RUN pip install --no-cache-dir \
+      "jupyter-ai>=3,<4" \
+      "jupyter-geoagent @ git+https://github.com/boettiger-lab/jupyter-geoagent.git@main"
+
+USER ${NB_UID}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds a minimal JupyterHub single-user image with this extension plus jupyter-ai (Claude + OpenCode personas) pre-installed, and publishes to `ghcr.io/boettiger-lab/jupyter-geoagent`.

### Base image

`quay.io/jupyter/minimal-notebook` — Debian + JupyterLab 4, NB_USER=jovyan. Much leaner than the Rocker geospatial/ML image at `ghcr.io/boettiger-lab/k8s`; strip down to the minimum that supports our Jupyter extension plus the three LLM persona binaries.

### What's installed

| Layer | What | Why |
|---|---|---|
| apt | `nodejs`, `npm` | The Claude ACP bridge is an npm package |
| bash installer | Claude Code CLI | Terminal use + availability of the binary |
| bash installer | OpenCode CLI | jupyter-ai OpenCode persona spawns it |
| npm global | `@zed-industries/claude-agent-acp` | jupyter-ai Claude persona spawns it |
| pip | `jupyter-ai>=3,<4` | Brings in acp-client, chat-commands, persona-manager, router, tools |
| pip (git) | `jupyter-geoagent@main` | This extension — every main push rebakes the image |

### Notable fix

The Claude Code installer drops a versioned binary tree at `$HOME/.local/share/claude/versions/<ver>/` with a symlink `$HOME/.local/bin/claude` pointing to it. The existing Rocker `install-claude.sh` moves the symlink to `/usr/local/bin` but then deletes the symlink's target, producing a dangling symlink (`claude: command not found`). This image moves the whole binary tree to `/opt/claude` and retargets the symlink so `claude` actually runs. We should upstream this fix to the Rocker image separately.

### Workflow triggers

- Push to `main` → build + push to GHCR (rebakes with the latest extension)
- PR touching `docker/**` or the workflow → build only, no push (validation)
- `workflow_dispatch` → manual build + push

### Verified locally

```
$ docker run --rm --entrypoint bash jupyter-geoagent-minimal:test -lc \
    'which claude claude-agent-acp opencode node npm; claude --version'
/usr/local/bin/claude
/usr/local/bin/claude-agent-acp
/usr/local/bin/opencode
/usr/bin/node
/usr/bin/npm
2.1.119 (Claude Code)
```

Lab extensions enabled: `@boettiger-lab/jupyter-geoagent`, `@jupyter-ai/*`, `jupyterlab-commands-toolkit`. Server extensions validated.

## Test plan

- [ ] CI run on the PR builds the image successfully (no push)
- [ ] Once merged, a `ghcr.io/boettiger-lab/jupyter-geoagent:latest` tag appears
- [ ] Pulling and running it in a JupyterHub pod: GeoAgent Map launcher tile appears, @Claude and @OpenCode personas available, the full geoagent:* command set is discoverable via `list_all_commands`