### PR TITLE
docs: mention the prebuilt container image on the landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,10 +9,24 @@ A JupyterLab extension for interactive geospatial data exploration: browse STAC 
 
 ## Install
 
+### As a Python package
+
 ```bash
 pip install jupyter-geoagent
 ```
 
 See the project [README on GitHub](https://github.com/boettiger-lab/jupyter-geoagent) for development setup.
+
+### As a container image (recommended for JupyterHub)
+
+A pre-built, minimal JupyterHub single-user image ships with jupyter-geoagent plus [jupyter-ai](https://jupyter-ai.readthedocs.io/) v3 and both the Claude and OpenCode ACP personas wired up:
+
+```
+ghcr.io/boettiger-lab/jupyter-geoagent:latest
+```
+
+Everything needed for the full chat-driven workflow (GeoAgent Map panel + `@Claude` / `@OpenCode` personas + `geoagent:*` JupyterLab commands) is pre-configured — no per-pod install step. Rebuilt on every push to `main`, so `:latest` always tracks the current release. Immutable tags (`sha-<commit>`) are also published.
+
+Built from [`docker/Dockerfile`](https://github.com/boettiger-lab/jupyter-geoagent/blob/main/docker/Dockerfile) — base image is `quay.io/jupyter/minimal-notebook`.
 
 ![GeoAgent Map panel showing the STAC catalog browser, interactive map, and layer controls](images/geoagent-panel.png)


### PR DESCRIPTION
## Summary

Follow-up docs for #12. The Install section on `docs/index.md` now has two paths:

- **As a Python package** — `pip install jupyter-geoagent` (unchanged)
- **As a container image** — `ghcr.io/boettiger-lab/jupyter-geoagent:latest`, recommended for JupyterHub deployments since it bundles jupyter-ai v3 + Claude + OpenCode ACP personas ready-to-use.

Notes that `:latest` tracks `main` and that immutable `sha-*` tags are also available, plus a link to the source Dockerfile for reference.