### PR TITLE
Add support for gh-scoped-creds on CryoCloud

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,4 +58,10 @@ COPY AGENTS.md CLAUDE.md /usr/local/share/jupyter-geoagent/
 COPY install-agent-md.sh /usr/local/bin/before-notebook.d/00-install-agent-md.sh
 RUN chmod +x /usr/local/bin/before-notebook.d/00-install-agent-md.sh
 
+# Enable GitHub Scoped Creds usage on CryoCloud
+# https://github.com/jupyterhub/gh-scoped-creds
+# TODO: Make this image hub-agnostic!
+ENV GH_SCOPED_CREDS_CLIENT_ID="Iv1.bd27058fd393e285"
+ENV GH_SCOPED_CREDS_APP_URL="https://github.com/apps/cryocloud-github-access"
+
 USER ${NB_UID}

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,3 +1,4 @@
+gh-scoped-creds
 jupyter-ai>=3,<4
 jupyter-geoagent @ git+https://github.com/geojupyter/jupyter-geoagent.git@main
 jupyter-myst-build-proxy


### PR DESCRIPTION
gh-scoped-creds will only work on CryoCloud with this change, but the correct solution is probably asking 2i2c to do some kubernetes magic to set these envvars for every image that is booted in CryoCloud instead of baking it in to the image. I assume that's possible but don't know.... And we don't have time for that before Fernando's talk!