### PR TITLE
Hack: Pin `jupyter-server-proxy==4.4.0`

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -2,3 +2,4 @@ gh-scoped-creds
 jupyter-ai>=3,<4
 jupyter-geoagent @ git+https://github.com/geojupyter/jupyter-geoagent.git@main
 jupyter-myst-build-proxy
+jupyter-server-proxy==4.4.0


### PR DESCRIPTION
When using the current version 4.5.0, the jupyter-myst-build-proxy extension stops working. When right-clicking `myst.yml` and selecting "Build MyST site...", the file browser is displayed instead of the build splash screen. Downgrading this dependency alone seems to resolve.