### PR TITLE
Add open-source hygiene: Code of Conduct, Contributing guide, and citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,34 @@
+{
+  "title": "jupyter-geoagent: A JupyterLab extension for interactive geospatial data exploration via STAC catalogs and MCP-powered queries",
+  "description": "jupyter-geoagent is a JupyterLab extension for GUI-driven, interactive geospatial data exploration. It provides a STAC catalog browser, an interactive MapLibre GL JS map, layer management, an MCP-powered DuckDB query interface over cloud-hosted parquet data, and reproducible exports.",
+  "license": "BSD-3-Clause",
+  "upload_type": "software",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Boettiger, Carl",
+      "affiliation": "University of California, Berkeley",
+      "orcid": "0000-0002-1642-628X"
+    },
+    {
+      "name": "Fisher, Matt"
+    },
+    {
+      "name": "Buhler, Cassie"
+    },
+    {
+      "name": "Pérez, Fernando",
+      "affiliation": "University of California, Berkeley"
+    }
+  ],
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension",
+    "geospatial",
+    "stac",
+    "maplibre",
+    "duckdb",
+    "mcp"
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "jupyter-geoagent: A JupyterLab extension for interactive geospatial data exploration via STAC catalogs and MCP-powered queries"
+abstract: >-
+  jupyter-geoagent is a JupyterLab extension for GUI-driven, interactive
+  geospatial data exploration. It provides a STAC catalog browser, an
+  interactive MapLibre GL JS map, layer management, an MCP-powered DuckDB
+  query interface over cloud-hosted parquet data, and reproducible exports.
+type: software
+authors:
+  - family-names: Boettiger
+    given-names: Carl
+    email: cboettig@berkeley.edu
+    affiliation: "University of California, Berkeley"
+    orcid: "https://orcid.org/0000-0002-1642-628X"
+  - family-names: Fisher
+    given-names: Matt
+  - family-names: Buhler
+    given-names: Cassie
+  - family-names: Pérez
+    given-names: Fernando
+    affiliation: "University of California, Berkeley"
+repository-code: "https://github.com/geojupyter/jupyter-geoagent"
+url: "https://jupyter-geoagent.readthedocs.io/"
+license: BSD-3-Clause
+keywords:
+  - jupyter
+  - jupyterlab
+  - jupyterlab-extension
+  - geospatial
+  - stac
+  - maplibre
+  - duckdb
+  - mcp

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+cboettig@berkeley.edu.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to jupyter-geoagent
+
+Thanks for your interest in contributing! `jupyter-geoagent` is a JupyterLab
+extension for interactive geospatial data exploration via STAC catalogs and
+MCP-powered queries. Contributions of all kinds are welcome — bug reports,
+documentation, feature ideas, and code.
+
+By participating in this project you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+- **Report bugs** or request features by opening an
+  [issue](https://github.com/geojupyter/jupyter-geoagent/issues).
+- **Improve the docs** in [`docs/`](docs/) — the user guide (`docs/usage.md`)
+  and design spec (`docs/design.md`).
+- **Fix bugs or add features** by opening a pull request.
+
+Before starting significant work, please open an issue to discuss the approach
+so we can avoid duplicated effort.
+
+## Development setup
+
+This is a hybrid Python + TypeScript JupyterLab extension. You'll need Python
+>=3.10, Node.js, and JupyterLab >=4.5.
+
+```bash
+# Clone your fork
+git clone https://github.com/<your-username>/jupyter-geoagent.git
+cd jupyter-geoagent
+
+# Install in editable mode with dev, test, and docs dependencies
+pip install --editable . --group dev --group test --group docs
+
+# Link the extension for development
+jupyter labextension develop --overwrite .
+
+# Watch for changes (in two terminals)
+jlpm watch:src
+jupyter lab --no-browser
+```
+
+Rebuild the TypeScript after edits (or rely on `jlpm watch:src`), then refresh
+JupyterLab in your browser to pick up changes.
+
+## Running tests
+
+```bash
+# Python tests
+python -m pytest
+```
+
+## Code style and pre-commit
+
+This project uses [pre-commit](https://pre-commit.com/) to enforce formatting
+and linting. Please install and run the hooks before committing:
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
+```
+
+## Pull request process
+
+1. Fork the repository and create a topic branch off `main`.
+2. Make your change, adding tests and documentation where appropriate.
+3. Ensure `pre-commit run --all-files` and the test suite pass.
+4. Write a clear PR description explaining the motivation and the change.
+5. Reference any related issues (e.g. `Fixes #123`).
+
+A maintainer will review your PR. Please be responsive to review feedback —
+we aim to keep the process quick and friendly.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[BSD 3-Clause License](LICENSE) that covers the project.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ jupyter lab --no-browser
 
 - **User guide:** how to use the extension day-to-day. Published at <https://jupyter-geoagent.readthedocs.io/> or read the source at [docs/usage.md](docs/usage.md).
 - **Design specification:** architecture and module reuse reference for contributors at [docs/design.md](docs/design.md).
+
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development
+setup and the pull request process. By participating you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Citation
+
+If you use `jupyter-geoagent` in your work, please cite it. Citation metadata is
+available in [CITATION.cff](CITATION.cff), and GitHub's "Cite this repository"
+button renders it in APA and BibTeX. Archived releases are available on Zenodo.


### PR DESCRIPTION
Adds standard open-source community and citation files.

## What's included

- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1, with `cboettig@berkeley.edu` as the enforcement contact.
- **CONTRIBUTING.md** — how to contribute: dev setup (editable install + `labextension develop`), running tests, `pre-commit`, and the PR process. Cross-links the Code of Conduct and LICENSE.
- **CITATION.cff** — machine-readable citation metadata. GitHub renders a "Cite this repository" button (APA/BibTeX) from this, and Zenodo reads it on release.
- **.zenodo.json** — Zenodo deposit metadata (title, description, creators, license, keywords) for archived releases via the GitHub–Zenodo integration.
- **README.md** — new Contributing and Citation sections linking the above.

## Notes

- Authors in the citation files are drawn from `git shortlog` (Carl Boettiger, Matt Fisher, Cassie Buhler, Fernando Pérez). Please adjust author list / ORCIDs / affiliations as desired before merging.
- License references match the existing BSD-3-Clause `LICENSE`.

<!-- readthedocs-preview jupyter-geoagent start -->
---
:mag: Docs preview: https://jupyter-geoagent--40.org.readthedocs.build/en/40/

<!-- readthedocs-preview jupyter-geoagent end -->