### PR TITLE
Add PyPI release workflow (trusted publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: release
+
+on:
+  release:
+    types: [published]
+  pull_request:
+    branches: "*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+        with:
+          node-version: "24"
+      - name: Build sdist + wheel
+        run: |
+          python -m pip install build
+          python -m build
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Upload to PyPI
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/jupyter-geoagent
+    permissions:
+      id-token: write
+    steps:
+      - name: Get dists artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - name: Upload dists to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
Adds `.github/workflows/release.yml`, mirroring the jupyter-sidekick release workflow.

- **On every PR:** builds the sdist + wheel so packaging breakage is caught early.
- **On a published GitHub Release:** uploads to PyPI via **OIDC trusted publishing** (`pypa/gh-action-pypi-publish`, `id-token: write`, `pypi` environment) — no API tokens stored in the repo.

Verified locally: `python -m build` succeeds and `twine check` passes both artifacts; the wheel contains the compiled `@geojupyter/jupyter-geoagent` labextension and the server config.

### Before the first release can publish
PyPI trusted publishing needs a one-time **pending publisher** registered on PyPI (project does not exist yet):
- Project name: `jupyter-geoagent`
- Owner: `geojupyter`  ·  Repo: `jupyter-geoagent`
- Workflow: `release.yml`  ·  Environment: `pypi`

Then cutting a GitHub Release for `v0.1.0` triggers the publish.

<!-- readthedocs-preview jupyter-geoagent start -->
---
:mag: Docs preview: https://jupyter-geoagent--41.org.readthedocs.build/en/41/

<!-- readthedocs-preview jupyter-geoagent end -->