### PR TITLE
Fix .zenodo.json license id so DOI minting succeeds

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "jupyter-geoagent: A JupyterLab extension for interactive geospatial data exploration via STAC catalogs and MCP-powered queries",
   "description": "jupyter-geoagent is a JupyterLab extension for GUI-driven, interactive geospatial data exploration. It provides a STAC catalog browser, an interactive MapLibre GL JS map, layer management, an MCP-powered DuckDB query interface over cloud-hosted parquet data, and reproducible exports.",
-  "license": "BSD-3-Clause",
+  "license": "bsd-3-clause",
   "upload_type": "software",
   "access_right": "open",
   "creators": [


### PR DESCRIPTION
Minting a Zenodo DOI on release currently fails with **HTTP 400**.

**Cause:** `license` is `"BSD-3-Clause"`. Zenodo (InvenioRDM) validates `license` against its SPDX vocabulary, whose identifiers are **lowercase**; the capitalized value isn't found and the deposit is rejected.

**Fix:** `"BSD-3-Clause"` → `"bsd-3-clause"`. No other fields changed.

Verified the file still parses as valid JSON.

<!-- readthedocs-preview jupyter-geoagent start -->
---
:mag: Docs preview: https://jupyter-geoagent--43.org.readthedocs.build/en/43/

<!-- readthedocs-preview jupyter-geoagent end -->