### PR TITLE
Pin geo-agent git dependency to a commit SHA

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "jupyter-geoagent: A JupyterLab extension for interactive geospatial data exploration via STAC catalogs and MCP-powered queries",
   "description": "jupyter-geoagent is a JupyterLab extension for GUI-driven, interactive geospatial data exploration. It provides a STAC catalog browser, an interactive MapLibre GL JS map, layer management, an MCP-powered DuckDB query interface over cloud-hosted parquet data, and reproducible exports.",
-  "license": "BSD-3-Clause",
+  "license": "bsd-3-clause",
   "upload_type": "software",
   "access_right": "open",
   "creators": [

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@jupyterlab/ui-components": "^4.5.1",
     "@lumino/widgets": "^2.3.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
-    "geo-agent": "git+https://github.com/boettiger-lab/geo-agent.git",
+    "geo-agent": "git+https://github.com/boettiger-lab/geo-agent.git#bd724a52c7e42d95de713c0d063d84ecd7074003",
     "maplibre-gl": "^5.2.0",
     "pmtiles": "^3.0.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,7 +45,7 @@ __metadata:
     "@types/react": ^18.0.26
     "@types/react-dom": ^18.0.10
     css-loader: ^6.7.1
-    geo-agent: "git+https://github.com/boettiger-lab/geo-agent.git"
+    geo-agent: "git+https://github.com/boettiger-lab/geo-agent.git#bd724a52c7e42d95de713c0d063d84ecd7074003"
     maplibre-gl: ^5.2.0
     npm-run-all2: ^7.0.1
     pmtiles: ^3.0.7
@@ -2162,7 +2162,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"geo-agent@git+https://github.com/boettiger-lab/geo-agent.git":
+"geo-agent@git+https://github.com/boettiger-lab/geo-agent.git#bd724a52c7e42d95de713c0d063d84ecd7074003":
   version: 1.0.0
   resolution: "geo-agent@https://github.com/boettiger-lab/geo-agent.git#commit=bd724a52c7e42d95de713c0d063d84ecd7074003"
   checksum: bade973c6243ef99cc80ad6b297927427ffa45c92948e3742c25393464de3f83f9c7faba5607c1e2a0d5b3223ad843e834d1d47e2e60365194f839448529fcdb


### PR DESCRIPTION
`geo-agent` was declared as an unpinned git dependency:

```json
"geo-agent": "git+https://github.com/boettiger-lab/geo-agent.git"
```

So whenever upstream `HEAD` moves, `yarn.lock` drifts and CI's immutable install fails — exactly what broke the first `v0.1.0` release build (#42). Upstream HEAD has *already* moved past what we shipped (`bd724a5` → `c76da27`).

This pins to **`bd724a52c7e42d95de713c0d063d84ecd7074003`** — the exact commit `v0.1.0` was built and published from — so installs are reproducible and CI can't drift out from under us. No behavior change vs. the released package.

To adopt future geo-agent changes, bump the SHA deliberately in `package.json` and re-run `jlpm install`.

Verified locally: `CI=true jlpm install --immutable` passes.

<!-- readthedocs-preview jupyter-geoagent start -->
---
:mag: Docs preview: https://jupyter-geoagent--44.org.readthedocs.build/en/44/

<!-- readthedocs-preview jupyter-geoagent end -->