### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geojupyter/jupyter-geoagent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A JupyterLab extension for interactive geospatial data exploration via STAC catalogs and MCP-powered queries.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Patch release to mint a fresh Zenodo DOI with the corrected `.zenodo.json` license (`bsd-3-clause`). The v0.1.0 release predates that fix.

- Bumps `package.json` version 0.1.0 → 0.1.1 (source for the dynamic Python version)

Merge, then tag `v0.1.1` and publish a GitHub Release to trigger PyPI upload + Zenodo DOI.

<!-- readthedocs-preview jupyter-geoagent start -->
---
:mag: Docs preview: https://jupyter-geoagent--45.org.readthedocs.build/en/45/

<!-- readthedocs-preview jupyter-geoagent end -->